### PR TITLE
Custom row matchers in connections

### DIFF
--- a/resources/example-row-matcher.sql
+++ b/resources/example-row-matcher.sql
@@ -1,0 +1,93 @@
+-- An example of polymorphic row matcher. Accepts matching criteria as a json object.
+-- Example of matching criteria, taking `forum_example.person` as the starting table:
+--
+-- {
+--   "first_name": "íllérmø",  -- will also find "Guillermo"
+--   "post:author_id:rev": {    -- <related table>:<fk name>[:rev] (rev, for reverse, is included when the key is in the related table)
+--     "headline": "first post",
+--     "comment:post_id:rev": {
+--       "body": "awesome"
+--     }
+--   }
+-- }
+--
+-- When a relation is traversed, the original record is included in the foundset if ANY of the N records
+-- matches the criterion.
+--
+-- Another example, with `forum_example.post` as the starting table:
+--
+-- {
+--   "headline": "first post",
+--   "post:author_id": {
+--     "first_name": "Guillermo"
+--   }
+-- }
+
+CREATE OR REPLACE FUNCTION forum_example.row_match(in_row json, criteria jsonb) RETURNS boolean AS $$
+DECLARE
+  found int = 0;
+  attr text;
+  is_match boolean;
+  colon_pos int;
+  colon_pos2 int;
+  related_table text;
+  related_fk text;
+  related_criteria jsonb;
+  related_query text;
+  related_row record;
+  related_count int;
+BEGIN
+  RAISE NOTICE '*** %: %', in_row->>'id', in_row;
+
+  FOR attr IN SELECT jsonb_object_keys(criteria) LOOP
+    colon_pos = strpos(attr, ':');
+
+    -- 1. Apply local criteria
+    IF colon_pos = 0 THEN
+      RAISE NOTICE '- local attr: % (''%'') ?= ''%''', attr, in_row->>attr, criteria->>attr;
+      IF
+        ((in_row->>attr) IS NULL AND (criteria->>attr) IS NULL) OR
+        ((in_row->>attr) = (criteria->>attr)) OR
+        (unaccent((in_row->>attr)::text) ILIKE '%' || unaccent(criteria->>attr) || '%')
+      THEN
+        CONTINUE;
+      END IF;
+      RAISE NOTICE '  local attr: %: match NOK (null mismatch)', attr;
+      RETURN FALSE;
+
+    -- 2. Apply related criteria (attribute name examples: post:post_id (from comment) comment:post_id:rev (from post)
+    ELSE
+      related_table = substring(attr for colon_pos - 1);
+      related_fk = substring(attr from colon_pos + 1);
+      colon_pos2 = strpos(related_fk, ':');
+      related_criteria = criteria->>attr;
+      IF colon_pos2 > 0 THEN
+        related_fk = substring(related_fk for colon_pos2 - 1);
+      END IF;
+      RAISE NOTICE '- related attr (% table via %) ?= %', related_table, related_fk, related_criteria;
+      IF colon_pos2 > 0 THEN
+        -- 1-to-N query (will find 0, 1 or more rows)
+        related_query = format('SELECT * FROM forum_example.%I AS related WHERE related.%I = %L', related_table, related_fk, in_row->>'id');
+      ELSE
+        -- 1-to-1 query (will find 0, 1 rows)
+        related_query = format('SELECT * FROM forum_example.%I AS related WHERE related.id = %L', related_table, in_row->>related_fk);
+      END IF;
+      RAISE NOTICE '  * related query: %', related_query;
+      is_match = FALSE;
+      FOR related_row IN EXECUTE related_query LOOP
+        IF forum_example.row_match(row_to_json(related_row), related_criteria) THEN
+          is_match = TRUE;
+          EXIT;
+        END IF;
+      END LOOP;
+      IF NOT is_match THEN
+        RAISE NOTICE '  related attr: %: match NOK', attr;
+        RETURN FALSE;
+      END IF;
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE '*** %: match OK', in_row->>'id';
+  RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/graphql/schema/BuildToken.ts
+++ b/src/graphql/schema/BuildToken.ts
@@ -30,6 +30,11 @@ interface BuildToken {
     // If true then the default mutations for tables (e.g. createMyTable) will
     // not be created
     readonly disableDefaultMutations: boolean,
+    // If specified then the corresponding Postgres function (polymorphic) will be used for
+    // connection filtering, instead of the default condition. It will also cause the `condition`
+    // field in the GraphQL schema to be of type Json (instead of the default,
+    // collection-dependent type)
+    readonly pgRowMatcher: string | null,
   },
   // Hooks for adding custom fields/types into our schema.
   readonly _hooks: _BuildTokenHooks,

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -15,6 +15,11 @@ export type SchemaOptions = {
   // If true then the default mutations for tables (e.g. createMyTable) will
   // not be created
   disableDefaultMutations?: boolean,
+  // If specified then the corresponding Postgres function (polymorphic) will be used for
+  // connection filtering, instead of the default condition. It will also cause the `condition`
+  // field in the GraphQL schema to be of type Json (instead of the default,
+  // collection-dependent type)
+  pgRowMatcher?: string,
   // Some hooks to allow extension of the schema. Currently this API is
   // private. Use at your own risk.
   _hooks?: _BuildTokenHooks,
@@ -37,6 +42,7 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
       nodeIdFieldName: options.nodeIdFieldName || '__id',
       dynamicJson: options.dynamicJson || false,
       disableDefaultMutations: options.disableDefaultMutations || false,
+      pgRowMatcher: options.pgRowMatcher || null,
     },
     _hooks: options._hooks || {},
     _typeOverrides: options._typeOverrides || new Map(),

--- a/src/interface/collection/Condition.ts
+++ b/src/interface/collection/Condition.ts
@@ -25,6 +25,7 @@ type Condition =
   EqualCondition |
   LessThanCondition |
   GreaterThanCondition |
+  CustomMatcherCondition |
   RegexpCondition
 
 export default Condition
@@ -67,6 +68,14 @@ export namespace conditionHelpers {
   // TODO: test
   export function fieldEquals (name: string, value: mixed): Condition {
     return { type: 'FIELD', name, condition: { type: 'EQUAL', value } }
+  }
+
+  /**
+   * Creates a custom matcher condition
+   */
+   // TODO: test
+  export function customMatches (matcher: string, value: mixed): Condition {
+    return { type: 'CUSTOM_MATCHER', matcher, value }
   }
 }
 
@@ -149,6 +158,15 @@ type LessThanCondition = {
  */
 type GreaterThanCondition = {
   type: 'GREATER_THAN',
+  value: mixed,
+}
+
+/**
+ * A condition to be used with a native custom matcher function.
+ */
+type CustomMatcherCondition = {
+  type: 'CUSTOM_MATCHER',
+  matcher: string,
   value: mixed,
 }
 

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -37,6 +37,7 @@ program
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
   .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
+  .option('-f, --matcher <string>', 'name of custom Postgres function for row matching in connections. Disabled by default')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
 
 program.on('--help', () => console.log(`
@@ -70,6 +71,7 @@ const {
   classicIds = false,
   dynamicJson = false,
   disableDefaultMutations = false,
+  matcher: pgRowMatcher,
   showErrorStack,
 // tslint:disable-next-line no-any
 } = program as any
@@ -111,6 +113,7 @@ const server = createServer(postgraphql(pgConfig, schemas, {
   showErrorStack,
   disableQueryLog: false,
   enableCors,
+  pgRowMatcher,
 }))
 
 // Start our server by listening to a specific port and host name. Also log

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -20,6 +20,7 @@ type PostGraphQLOptions = {
   disableQueryLog?: boolean,
   disableDefaultMutations?: boolean,
   enableCors?: boolean,
+  pgRowMatcher?: string,
 }
 
 /**

--- a/src/postgraphql/schema/createPostGraphQLSchema.ts
+++ b/src/postgraphql/schema/createPostGraphQLSchema.ts
@@ -25,6 +25,7 @@ export default async function createPostGraphQLSchema (
     jwtSecret?: string,
     jwtPgTypeIdentifier?: string,
     disableDefaultMutations?: boolean,
+    pgRowMatcher?: string,
   } = {},
 ): Promise<GraphQLSchema> {
   // Create our inventory.
@@ -108,6 +109,7 @@ export default async function createPostGraphQLSchema (
     nodeIdFieldName: options.classicIds ? 'id' : '__id',
     dynamicJson: options.dynamicJson,
     disableDefaultMutations: options.disableDefaultMutations,
+    pgRowMatcher: options.pgRowMatcher,
 
     // If we have a JWT Postgres type, let us override the GraphQL output type
     // with our own.

--- a/src/postgres/inventory/conditionToSql.ts
+++ b/src/postgres/inventory/conditionToSql.ts
@@ -31,6 +31,10 @@ export default function conditionToSql (condition: Condition, path: Array<string
       if (!match) throw new Error('Invalid regular expression.')
       const [, pattern, flags] = match
       return sql.query`regexp_matches(${sql.identifier(...path)}, ${sql.value(pattern)}, ${sql.value(flags)})`
+    case 'CUSTOM_MATCHER':
+      // We use `sql.raw` (beware of its dangers!) since the matcher is provided by the (server-side) user
+      // Since it does not come from the GraphQL interface, it can be trusted
+      return sql.query`${sql.raw(condition.matcher)}(to_json(${sql.identifier(Symbol.for('mainSelect'))}), ${sql.value(condition.value)})`
     default:
       throw new Error(`Condition of type '${condition['type']}' is not recognized.`)
   }

--- a/src/postgres/inventory/paginator/PgPaginator.ts
+++ b/src/postgres/inventory/paginator/PgPaginator.ts
@@ -32,7 +32,7 @@ abstract class PgPaginator<TInput, TItemValue> implements Paginator<TInput, TIte
     const client = pgClientFromContext(context)
     const fromSql = this.getFromEntrySql(input)
     const conditionSql = this.getConditionSql(input)
-    const aliasIdentifier = Symbol()
+    const aliasIdentifier = Symbol.for('mainSelect')
     const result = await client.query(sql.compile(sql.query`select count(${sql.identifier(aliasIdentifier)}) as count from ${fromSql} as ${sql.identifier(aliasIdentifier)} where ${conditionSql}`))
     return parseInt(result.rows[0]['count'], 10)
   }

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
@@ -66,7 +66,7 @@ implements Paginator.Ordering<TInput, PgObjectType.Value, AttributesCursor> {
     if (beforeCursor != null && beforeCursor.length !== pgAttributes.length)
       throw new Error('Before cursor must be a value tuple of the correct length.')
 
-    const aliasIdentifier = Symbol()
+    const aliasIdentifier = Symbol.for('mainSelect')
     const fromSql = this.pgPaginator.getFromEntrySql(input)
     const conditionSql = this.pgPaginator.getConditionSql(input)
 
@@ -129,9 +129,10 @@ implements Paginator.Ordering<TInput, PgObjectType.Value, AttributesCursor> {
         const lastCursor = lastValue ? lastValue.cursor : beforeCursor
         if (lastCursor == null) return false
 
+        const aliasIdentifier = Symbol.for('mainSelect')
         const { rowCount } = await client.query(sql.compile(sql.query`
           select null
-          from ${fromSql}
+          from ${fromSql} as ${sql.identifier(aliasIdentifier)}
           where ${this._getCursorCondition(pgAttributes, lastCursor, descending ? '<' : '>')} and ${conditionSql}
           limit 1
         `))
@@ -146,9 +147,10 @@ implements Paginator.Ordering<TInput, PgObjectType.Value, AttributesCursor> {
         const firstCursor = firstValue ? firstValue.cursor : afterCursor
         if (firstCursor == null) return false
 
+        const aliasIdentifier = Symbol.for('mainSelect')
         const { rowCount } = await client.query(sql.compile(sql.query`
           select null
-          from ${fromSql}
+          from ${fromSql} as ${sql.identifier(aliasIdentifier)}
           where ${this._getCursorCondition(pgAttributes, firstCursor, descending ? '>' : '<')} and ${conditionSql}
           limit 1
         `))

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
@@ -121,7 +121,7 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
       limit = last
     }
 
-    const aliasIdentifier = Symbol()
+    const aliasIdentifier = Symbol.for('mainSelect')
     const fromSql = this.pgPaginator.getFromEntrySql(input)
     const conditionSql = this.pgPaginator.getConditionSql(input)
 


### PR DESCRIPTION
**Motivation**: It would be nice to add flexibility to connection filtering (multi-table, multi-field, non-equality comparisons, etc.) without losing the ability to paginate with cursors. Currently, if the user implements a custom row matcher in the database (e.g. `search_posts()` in the forum example), he loses the great cursor-based pagination supported on collections.

**Implementation**: When the user specifies a custom row matcher (via the new `--matcher` CLI flag, or `pgRowMatcher` library option), the `condition` field of all GraphQL connections is re-defined as having type `Json`, and all connection rows are validated (in the `where` clause) through the specified row matcher. This new *condition clause* is used in both offset- and attribute-based orderings, and for all pagination fields: `hasNextPage`, `hasPreviousPage`, `count`, etc.

An example of a polymorphic row matcher with support for nested conditions, partial matches (only equality for the time being) and diacritic removal, can be found under the `examples` folder. I believe this solution gives a great degree of freedom to the user to implement whichever filtering strategies he needs.

Regarding the multiple-field, multiple-table sorting feature I mentioned in #224, that's a quite complex problem that requires further thought. This PR, while still limited to the single-attribute orderings available in the library, is just a stepping stone in that direction.