### PR TITLE
Adds optional properties to update/set created and modified timestamps.

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -62,6 +62,7 @@ Arguments include:
   - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does. This feature requires an event trigger to be added to the database by a superuser. When enabled PostGraphQL will try to add this trigger, if you did not connect as a superuser you will get a warning and the trigger won’t be added.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.
   - `enableCors`: Enables some generous CORS settings for the GraphQL endpoint. There are some costs associated when enabling this, if at all possible try to put your API behind a reverse proxy.
+  - `timestamps`: Enables automatic setting of timestamps to fields when editing/creating new rows. `null`, the default, indicates that no fields should be set. `{modified: 'lastMod'}` would indicate that the `lastMod` field is set on modification. `{created: 'init', modified: 'lastMod'}` would additionally sets `created` to the creation timestamp once a new row is created.  
 
 [connect]: https://www.npmjs.com/connect
 [express]: https://www.npmjs.com/express

--- a/src/graphql/schema/BuildToken.ts
+++ b/src/graphql/schema/BuildToken.ts
@@ -1,6 +1,13 @@
 import { GraphQLOutputType, GraphQLFieldConfig } from 'graphql'
 import { Inventory, Type, ObjectType } from '../../interface'
 
+interface BuildTokenTimestamps {
+  // Field name to be set on modification with the current timestamp
+  modified?: string,
+  // Field name to be set on creation with the current timestamp
+  created?: string,
+}
+
 /**
  * A `BuildToken` is a plain object that gets passed around to all of the
  * functions used to create a GraphQL schema. The `BuildToken` contains a copy
@@ -30,6 +37,9 @@ interface BuildToken {
     // If true then the default mutations for tables (e.g. createMyTable) will
     // not be created
     readonly disableDefaultMutations: boolean,
+    // If timestamps are given the fields are excluded from create/modify
+    // queries and automatically filled
+    readonly timestamps?: BuildTokenTimestamps,
   },
   // Hooks for adding custom fields/types into our schema.
   readonly _hooks: _BuildTokenHooks,

--- a/src/graphql/schema/collection/mutations/__tests__/createCreateCollectionMutationFieldEntry-test.js
+++ b/src/graphql/schema/collection/mutations/__tests__/createCreateCollectionMutationFieldEntry-test.js
@@ -1,0 +1,112 @@
+jest.mock('../../../getGqlType')
+jest.mock('../../../createMutationGqlField')
+jest.mock('../../getCollectionGqlType')
+jest.mock('../../../transformGqlInputValue')
+
+import getGqlType from '../../../getGqlType'
+import transformGqlInputValue from '../../../transformGqlInputValue'
+import createMutationGqlField from '../../../createMutationGqlField'
+import getCollectionGqlType from '../../getCollectionGqlType'
+import createCreateCollectionMutationFieldEntry from '../createCreateCollectionMutationFieldEntry'
+
+createMutationGqlField.mockImplementation((buildToken, config) => Object.assign(config, { buildToken }))
+
+beforeEach(() => {
+  getGqlType.mockClear()
+  transformGqlInputValue.mockClear()
+  createMutationGqlField.mockClear()
+  getCollectionGqlType.mockClear()
+})
+
+test('will return undefined if create is not defined', () => {
+  expect(createCreateCollectionMutationFieldEntry({}, {})).toBe(undefined)
+})
+
+test('will create a field entry with the correct name', () => {
+  const buildToken = Symbol('buildToken')
+  const type = { name: 'person', getFields: () => ({}) }
+  const collection = { name: 'people', type, create: true }
+  const fieldEntry = createCreateCollectionMutationFieldEntry(buildToken, collection)
+  expect(fieldEntry[0]).toBe('createPerson')
+  expect(fieldEntry[1].buildToken).toBe(buildToken)
+  expect(fieldEntry[1].name).toBe('create_person')
+})
+
+test('will create a field entry with the correct input fields', () => {
+  const gqlType = Symbol('gqlType')
+  getGqlType.mockReturnValueOnce(gqlType)
+  const buildToken = Symbol('buildToken')
+  const type = { name: 'person', getFields: () => ({}) }
+  const collection = { name: 'people', type, create: true }
+  const fieldEntry = createCreateCollectionMutationFieldEntry(buildToken, collection)
+  expect(fieldEntry[1].inputFields).toEqual([['person', { type: gqlType, description: 'The `` to be created by this mutation.' }]])
+  expect(getGqlType.mock.calls).toEqual([[buildToken, type, true]])
+})
+
+test('will create a field entry with output fields and no paginator', () => {
+  const gqlCollectionType = Symbol('gqlCollectionType')
+  getCollectionGqlType.mockReturnValueOnce(gqlCollectionType)
+  const value = Symbol('value')
+  const buildToken = Symbol('buildToken')
+  const type = { name: 'person', getFields: () => ({}) }
+  const collection = { name: 'people', type, create: true }
+  const fieldEntry = createCreateCollectionMutationFieldEntry(buildToken, collection)
+  expect(fieldEntry[1].outputFields[0][0]).toBe('person')
+  expect(fieldEntry[1].outputFields[0][1].type).toBe(gqlCollectionType)
+  expect(fieldEntry[1].outputFields[0][1].resolve(value)).toBe(value)
+  expect(fieldEntry[1].outputFields[1]).toBeFalsy()
+  expect(getCollectionGqlType.mock.calls).toEqual([[buildToken, collection]])
+})
+
+const dateTest = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
+
+test('will not create with timestamps if timestamps not in buildToken', () => {
+  const expectedResult = new Map()
+  const type = { name: 'person', getFields: () => ({}) }
+  const value = Symbol('value')
+  const buildToken = {
+    options: {
+      timestamps: {
+        created: 'fieldA',
+        modified: 'fieldB',
+      },
+    },
+  }
+  const collection = { name: 'people', type, create: (ctx, output) => output }
+  getCollectionGqlType.mockReturnValue(type)
+  transformGqlInputValue.mockReturnValue(expectedResult)
+
+  const fieldEntry = createCreateCollectionMutationFieldEntry(buildToken, collection)
+  const [ fieldName, fieldSchema ] = fieldEntry
+
+  const result = fieldSchema.execute({}, {})
+  expect(result).toBe(expectedResult)
+  expect(result.get('fieldA')).toBe(undefined)
+  expect(result.get('fieldB')).toBe(undefined)
+})
+
+test('will create with timestamps if timestamps are given in buildToken', () => {
+  const expectedResult = new Map()
+  const type = { name: 'person', getFields: () => ({
+    fieldA: { type: 'string' },
+    fieldB: { type: 'string' },
+  }) }
+  const value = Symbol('value')
+  const buildToken = { options: {
+    timestamps: {
+      created: 'fieldA',
+      modified: 'fieldB',
+    },
+  } }
+  const collection = { name: 'people', type, create: (ctx, output) => output }
+  getCollectionGqlType.mockReturnValue(type)
+  transformGqlInputValue.mockReturnValue(expectedResult)
+
+  const fieldEntry = createCreateCollectionMutationFieldEntry(buildToken, collection)
+  const [ fieldName, fieldSchema ] = fieldEntry
+
+  const result = fieldSchema.execute({}, {})
+  expect(result).toBe(expectedResult)
+  expect(result.get('fieldA')).toMatch(dateTest)
+  expect(result.get('fieldB')).toMatch(dateTest)
+})

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -15,6 +15,14 @@ export type SchemaOptions = {
   // If true then the default mutations for tables (e.g. createMyTable) will
   // not be created
   disableDefaultMutations?: boolean,
+  // If timestamps are given the fields are excluded from create/modify
+  // queries and automatically filled
+  timestamps?: {
+    // Field name to be set on modification with the current timestamp
+    modified?: string,
+    // Field name to be set on creation with the current timestamp
+    created?: string,
+  },
   // Some hooks to allow extension of the schema. Currently this API is
   // private. Use at your own risk.
   _hooks?: _BuildTokenHooks,
@@ -37,6 +45,7 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
       nodeIdFieldName: options.nodeIdFieldName || '__id',
       dynamicJson: options.dynamicJson || false,
       disableDefaultMutations: options.disableDefaultMutations || false,
+      timestamps: options.timestamps,
     },
     _hooks: options._hooks || {},
     _typeOverrides: options._typeOverrides || new Map(),

--- a/src/graphql/utils/__tests__/tsForCollection-test.ts
+++ b/src/graphql/utils/__tests__/tsForCollection-test.ts
@@ -1,0 +1,64 @@
+import tsForCollection from '../tsForCollection'
+import Collection from '../../../interface/collection/Collection'
+
+/* tslint:disable:no-any */
+function cast<TType>(input: any): TType {
+  return input
+}
+/* tslint:enable:no-any */
+
+test('no timestamps, no fields', () => {
+  expect(tsForCollection(cast<Collection<mixed>>({
+    type: {
+      fields: {},
+    },
+  }), undefined)).toBe(undefined)
+})
+
+test('empty timestamps should result in undefined timestamps', () => {
+  expect(tsForCollection(cast<Collection<mixed>>({
+    type: {
+      fields: {},
+    },
+  }), {})).toBe(undefined)
+})
+
+test('no fields should result in no timestamps', () => {
+  expect(tsForCollection(cast<Collection<mixed>>({
+    type: {
+      fields: {},
+    },
+  }), {
+    created: 'x',
+    modified: 'y',
+  })).toBe(undefined)
+})
+
+test('created fields should result in created timestamps', () => {
+  expect(tsForCollection(cast<Collection<mixed>>({
+    type: {
+      fields: {
+        x: 'a',
+      },
+    },
+  }), {
+    created: 'x',
+    modified: 'y',
+  })).toEqual({
+    created: 'x',
+  })
+})
+test('created fields should result in created timestamps', () => {
+  expect(tsForCollection(cast<Collection<mixed>>({
+    type: {
+      fields: {
+        y: 'a',
+      },
+    },
+  }), {
+    created: 'x',
+    modified: 'y',
+  })).toEqual({
+    modified: 'y',
+  })
+})

--- a/src/graphql/utils/index.ts
+++ b/src/graphql/utils/index.ts
@@ -2,8 +2,9 @@ import buildObject from './buildObject'
 import formatName from './formatName'
 import idSerde from './idSerde'
 import scrib from './scrib'
+import tsForCollection from './tsForCollection'
 import parseGqlLiteralToValue from './parseGqlLiteralToValue'
 
-export { buildObject, formatName, idSerde, scrib, parseGqlLiteralToValue }
+export { buildObject, formatName, idSerde, scrib, parseGqlLiteralToValue, tsForCollection }
 
 export * from './memoize'

--- a/src/graphql/utils/tsForCollection.ts
+++ b/src/graphql/utils/tsForCollection.ts
@@ -1,0 +1,33 @@
+import Collection from '../../interface/collection/Collection'
+
+type Timestamps = {
+  created?: string;
+  modified?: string;
+}
+
+function tsFromCreated (fields: mixed, created?: string): Timestamps | undefined {
+  if (created && fields && fields[created]) {
+    return { created }
+  }
+}
+
+function tsFromModified (fields: mixed, timestamps?: Timestamps, modified?: string): Timestamps | undefined {
+  if (modified && fields && fields[modified]) {
+    if (timestamps) {
+      timestamps.modified = modified
+    } else {
+      return { modified }
+    }
+  }
+  return timestamps
+}
+
+function tsForCollection (collection: Collection<mixed>, timestamps?: Timestamps): Timestamps | undefined {
+  if (!timestamps) {
+    return
+  }
+  const fields = collection.type.fields
+  let newTimestamps = tsFromCreated(fields, timestamps.created)
+  return tsFromModified(fields, newTimestamps, timestamps.modified)
+}
+export default tsForCollection

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -37,6 +37,8 @@ program
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
   .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
+  .option('-C, --timestamp-created <string>', 'field to be set to the current timestamp upon creation')
+  .option('-T, --timestamp-modified <string>', 'field to be set to the current timestamp upon modification')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
 
 program.on('--help', () => console.log(`
@@ -71,6 +73,8 @@ const {
   dynamicJson = false,
   disableDefaultMutations = false,
   showErrorStack,
+  timestampCreated,
+  timestampModified,
 // tslint:disable-next-line no-any
 } = program as any
 
@@ -95,6 +99,14 @@ const pgConfig = Object.assign(
   { max: maxPoolSize },
 )
 
+let timestamps
+if (timestampCreated || timestampModified) {
+  timestamps = {
+    created: timestampCreated,
+    modified: timestampModified,
+  }
+}
+
 // Create’s our PostGraphQL server and provides all the appropriate
 // configuration options.
 const server = createServer(postgraphql(pgConfig, schemas, {
@@ -111,6 +123,7 @@ const server = createServer(postgraphql(pgConfig, schemas, {
   showErrorStack,
   disableQueryLog: false,
   enableCors,
+  timestamps,
 }))
 
 // Start our server by listening to a specific port and host name. Also log

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -30,7 +30,7 @@ const { POSTGRAPHQL_ENV } = process.env
 const debugGraphql = new Debugger('postgraphql:graphql')
 const debugRequest = new Debugger('postgraphql:request')
 
-export const graphiqlDirectory = resolvePath(__dirname, '../graphiql/public')
+export const graphiqlDirectory = resolvePath(__dirname, '../../public/graphiql/public')
 
 /**
  * The favicon file in `Buffer` format. We can send a `Buffer` directly to the

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -21,6 +21,10 @@ type PostGraphQLOptions = {
   disableQueryLog?: boolean,
   disableDefaultMutations?: boolean,
   enableCors?: boolean,
+  timestamps?: {
+    created?: string,
+    modified?: string,
+  },
 }
 
 /**

--- a/src/postgraphql/schema/createPostGraphQLSchema.ts
+++ b/src/postgraphql/schema/createPostGraphQLSchema.ts
@@ -26,6 +26,10 @@ export default async function createPostGraphQLSchema (
     jwtSecret?: string,
     jwtPgTypeIdentifier?: string,
     disableDefaultMutations?: boolean,
+    timestamps?: {
+      modified?: string,
+      created?: string,
+    },
   } = {},
 ): Promise<GraphQLSchema> {
   // Create our inventory.
@@ -109,6 +113,7 @@ export default async function createPostGraphQLSchema (
     nodeIdFieldName: options.classicIds ? 'id' : '__id',
     dynamicJson: options.dynamicJson,
     disableDefaultMutations: options.disableDefaultMutations,
+    timestamps: options.timestamps,
 
     // If we have a JWT Postgres type, let us override the GraphQL output type
     // with our own.


### PR DESCRIPTION
Some databases use created/modified fields to mark changes in the data rows. Usually those fields are not meant to be set during api queries but automatically be filled. This PR adds a customizable options to postgraphql that allow setting the fields following a naming pattern.