### PR TITLE
Added primaryKeyAPI option

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -62,7 +62,7 @@ Arguments include:
   - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does. This feature requires an event trigger to be added to the database by a superuser. When enabled PostGraphQL will try to add this trigger, if you did not connect as a superuser you will get a warning and the trigger won’t be added.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.
   - `enableCors`: Enables some generous CORS settings for the GraphQL endpoint. There are some costs associated when enabling this, if at all possible try to put your API behind a reverse proxy.
-  - `primaryKeyAPI`: Unless multiple primary keys are defined PostGraphQL will only show the default endpoint for a type. By enableing `primaryKeyAPI` it will also add endpoints and fields for the default keys. 
+  - `primaryKeyAPI`: Unless multiple primary keys are defined PostGraphQL will only show the default endpoint for a type. By enabling `primaryKeyAPI` it will also add endpoints and fields for the default keys. 
 
 [connect]: https://www.npmjs.com/connect
 [express]: https://www.npmjs.com/express

--- a/docs/library.md
+++ b/docs/library.md
@@ -62,6 +62,7 @@ Arguments include:
   - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does. This feature requires an event trigger to be added to the database by a superuser. When enabled PostGraphQL will try to add this trigger, if you did not connect as a superuser you will get a warning and the trigger won’t be added.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.
   - `enableCors`: Enables some generous CORS settings for the GraphQL endpoint. There are some costs associated when enabling this, if at all possible try to put your API behind a reverse proxy.
+  - `primaryKeyAPI`: Unless multiple primary keys are defined PostGraphQL will only show the default endpoint for a type. By enableing `primaryKeyAPI` it will also add endpoints and fields for the default keys. 
 
 [connect]: https://www.npmjs.com/connect
 [express]: https://www.npmjs.com/express

--- a/src/graphql/schema/BuildToken.ts
+++ b/src/graphql/schema/BuildToken.ts
@@ -30,6 +30,8 @@ interface BuildToken {
     // If true then the default mutations for tables (e.g. createMyTable) will
     // not be created
     readonly disableDefaultMutations: boolean,
+    // Allows hiding primary keys from the API
+    readonly primaryKeyAPI?: boolean,
   },
   // Hooks for adding custom fields/types into our schema.
   readonly _hooks: _BuildTokenHooks,

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -20,6 +20,10 @@ export default function createCollectionGqlType<TValue> (
   const { options, inventory } = buildToken
   const { type, primaryKey } = collection
   const collectionTypeName = formatName.type(type.name)
+  let fields = Array.from(type.fields.entries())
+  if (primaryKey && !buildToken.options.primaryKeyAPI) {
+    fields = fields.filter(([ fieldName ]) => fieldName !== primaryKey.name)
+  }
 
   return new GraphQLObjectType({
     name: collectionTypeName,
@@ -42,7 +46,7 @@ export default function createCollectionGqlType<TValue> (
       ],
 
       // Add all of the basic fields to our type.
-      Array.from(type.fields).map(
+      fields.map(
         <TFieldValue>([fieldName, field]: [string, ObjectType.Field<TValue, TFieldValue>]) => {
           const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, field.type)
           return {

--- a/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
@@ -56,10 +56,12 @@ export default function createCollectionQueryFieldEntries <TValue>(
   // Add a field to select any value in the collection by any key. So all
   // unique keys of an object will be usable to select a single value.
   for (const collectionKey of (collection.keys || [])) {
-    const field = createCollectionKeyField(buildToken, collectionKey)
+    if (collectionKey !== primaryKey || buildToken.options.primaryKeyAPI) {
+      const field = createCollectionKeyField(buildToken, collectionKey)
 
-    // If we got a field back, add it.
-    if (field) entries.push([formatName.field(`${type.name}-by-${collectionKey.name}`), field])
+      // If we got a field back, add it.
+      if (field) entries.push([formatName.field(`${type.name}-by-${collectionKey.name}`), field])
+    }
   }
 
   return entries

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -15,6 +15,8 @@ export type SchemaOptions = {
   // If true then the default mutations for tables (e.g. createMyTable) will
   // not be created
   disableDefaultMutations?: boolean,
+  // Allows hiding primary keys from the API
+  primaryKeyAPI?: boolean,
   // Some hooks to allow extension of the schema. Currently this API is
   // private. Use at your own risk.
   _hooks?: _BuildTokenHooks,
@@ -37,6 +39,7 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
       nodeIdFieldName: options.nodeIdFieldName || '__id',
       dynamicJson: options.dynamicJson || false,
       disableDefaultMutations: options.disableDefaultMutations || false,
+      primaryKeyAPI: options.primaryKeyAPI,
     },
     _hooks: options._hooks || {},
     _typeOverrides: options._typeOverrides || new Map(),

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -37,6 +37,7 @@ program
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
   .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
+  .option('-y, --primary-key-api', 'enable additional endpoints to primary-key apis')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
 
 program.on('--help', () => console.log(`
@@ -71,6 +72,7 @@ const {
   dynamicJson = false,
   disableDefaultMutations = false,
   showErrorStack,
+  primaryKeyApi,
 // tslint:disable-next-line no-any
 } = program as any
 
@@ -111,6 +113,7 @@ const server = createServer(postgraphql(pgConfig, schemas, {
   showErrorStack,
   disableQueryLog: false,
   enableCors,
+  primaryKeyAPI: primaryKeyApi,
 }))
 
 // Start our server by listening to a specific port and host name. Also log

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -21,6 +21,7 @@ type PostGraphQLOptions = {
   disableQueryLog?: boolean,
   disableDefaultMutations?: boolean,
   enableCors?: boolean,
+  primaryKeyAPI?: boolean,
 }
 
 /**

--- a/src/postgraphql/schema/createPostGraphQLSchema.ts
+++ b/src/postgraphql/schema/createPostGraphQLSchema.ts
@@ -26,6 +26,7 @@ export default async function createPostGraphQLSchema (
     jwtSecret?: string,
     jwtPgTypeIdentifier?: string,
     disableDefaultMutations?: boolean,
+    primaryKeyAPI?: boolean,
   } = {},
 ): Promise<GraphQLSchema> {
   // Create our inventory.
@@ -109,6 +110,7 @@ export default async function createPostGraphQLSchema (
     nodeIdFieldName: options.classicIds ? 'id' : '__id',
     dynamicJson: options.dynamicJson,
     disableDefaultMutations: options.disableDefaultMutations,
+    primaryKeyAPI: options.primaryKeyAPI,
 
     // If we have a JWT Postgres type, let us override the GraphQL output type
     // with our own.


### PR DESCRIPTION
Currently postgraphql will create two endpoints for e every collection. `collectionName(__id:ID!)` and `collectionNameById(id: int)`. This PR will hide the second endpoint in favor for the first endpoint unless the `primaryKey` option is set.