### PR TITLE
Custom Naming Support

### DIFF
--- a/src/graphql/schema/BuildToken.ts
+++ b/src/graphql/schema/BuildToken.ts
@@ -1,5 +1,6 @@
 import { GraphQLOutputType, GraphQLFieldConfig } from 'graphql'
 import { Inventory, Type, ObjectType } from '../../interface'
+import FormatName from './FormatName'
 
 /**
  * A `BuildToken` is a plain object that gets passed around to all of the
@@ -30,6 +31,8 @@ interface BuildToken {
     // If true then the default mutations for tables (e.g. createMyTable) will
     // not be created
     readonly disableDefaultMutations: boolean,
+    // Allow overriding the formatting of common names
+    readonly formatName: FormatName,
   },
   // Hooks for adding custom fields/types into our schema.
   readonly _hooks: _BuildTokenHooks,
@@ -48,14 +51,21 @@ export type _BuildTokenHooks = {
   readonly objectTypeFieldEntries?: <TValue>(type: ObjectType<TValue>, _gqlBuildToken: BuildToken) => Array<[string, GraphQLFieldConfig<TValue, mixed>]>,
 }
 
+export type _BuildTokenTypeOverride = {
+  input?: true,
+  output?: GraphQLOutputType,
+}
+
+export type _BuildTokenTypeOverrideResolver = (_gqlBuildToken: BuildToken) => _BuildTokenTypeOverride
+
 /**
  * Overrides the GraphQL input and output of certain interface types. Can be
  * used for ‘special’ types that may be created from time to time. Currently
  * this is a private API.
  */
-export type _BuildTokenTypeOverrides = Map<Type<mixed>, {
-  input?: true,
-  output?: GraphQLOutputType,
-}>
+export type _BuildTokenTypeOverrides = Map<
+  Type<mixed>,
+  _BuildTokenTypeOverride | _BuildTokenTypeOverrideResolver
+>
 
 export default BuildToken

--- a/src/graphql/schema/FormatName.ts
+++ b/src/graphql/schema/FormatName.ts
@@ -6,27 +6,32 @@ type FormatName = {
 
   queryMethod: (type: string) => string,
   queryByKeyMethod: (type: string, key: string) => string,
+  queryRelationField: (type: string) => string,
+  queryRelationFieldByKeyMethod: (type: string, key: string) => string,
 
   queryAllMethod: (type: string) => string,
   queryAllOrderByType: (type: string) => string,
   queryAllEdgeType: (type: string) => string,
   queryAllRelationType: (type: string) => string,
   queryAllConditionType: (type: string) => string,
-
   queryAllEdgeFieldName: (type: string) => string,
+
   deleteMethod: (type: string) => string,
   deleteType: (type: string) => string,
   deleteByKeyMethod: (type: string, key: string) => string,
   deletedID: (type: string) => string,
 
-  inputType: (type: string) => string,
   mutationPayload: (type: string) => string,
+
+  createType: (type: string) => string,
   createMethod: (type: string) => string,
+
   updateType: (type: string) => string,
   updateByKeyMethod: (type: string, key: string) => string,
   updateMethod: (fieldName: string) => string,
-  updatePatchyType: (type: string) => string,
-  updateFieldPatch: (fieldName: string) => string,
+
+  updatePatchType: (type: string) => string,
+  updatePatchField: (fieldName: string) => string,
 }
 
 export default FormatName

--- a/src/graphql/schema/FormatName.ts
+++ b/src/graphql/schema/FormatName.ts
@@ -1,0 +1,8 @@
+type FormatName = {
+  readonly type: (fullName: string) => string,
+  readonly field: (fullName: string) => string,
+  readonly arg: (fullName: string) => string,
+  readonly enumValue: (fullName: string) => string,
+}
+
+export default FormatName

--- a/src/graphql/schema/FormatName.ts
+++ b/src/graphql/schema/FormatName.ts
@@ -1,8 +1,32 @@
 type FormatName = {
-  readonly type: (fullName: string) => string,
-  readonly field: (fullName: string) => string,
-  readonly arg: (fullName: string) => string,
-  readonly enumValue: (fullName: string) => string,
+  type: (fullName: string) => string,
+  field: (fullName: string) => string,
+  arg: (fullName: string) => string,
+  enumValue: (fullName: string) => string,
+
+  queryMethod: (type: string) => string,
+  queryByKeyMethod: (type: string, key: string) => string,
+
+  queryAllMethod: (type: string) => string,
+  queryAllOrderByType: (type: string) => string,
+  queryAllEdgeType: (type: string) => string,
+  queryAllRelationType: (type: string) => string,
+  queryAllConditionType: (type: string) => string,
+
+  queryAllEdgeFieldName: (type: string) => string,
+  deleteMethod: (type: string) => string,
+  deleteType: (type: string) => string,
+  deleteByKeyMethod: (type: string, key: string) => string,
+  deletedID: (type: string) => string,
+
+  inputType: (type: string) => string,
+  mutationPayload: (type: string) => string,
+  createMethod: (type: string) => string,
+  updateType: (type: string) => string,
+  updateByKeyMethod: (type: string, key: string) => string,
+  updateMethod: (fieldName: string) => string,
+  updatePatchyType: (type: string) => string,
+  updateFieldPatch: (fieldName: string) => string,
 }
 
 export default FormatName

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -83,7 +83,7 @@ export default function createCollectionGqlType<TValue> (
 
           const { gqlType: gqlConditionType, fromGqlInput: conditionFromGqlInput } = getConditionGqlType(buildToken, tailCollection.type)
           return [
-            formatName.field(`${tailCollection.name}-by-${relation.name}`),
+            formatName.queryByKeyMethod(tailCollection.name, relation.name),
             createConnectionGqlField<TValue, Condition, TTailValue>(buildToken, tailPaginator, {
               // The one input arg we have for this connection is the `condition` arg.
               inputArgEntries: [

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -83,7 +83,7 @@ export default function createCollectionGqlType<TValue> (
 
           const { gqlType: gqlConditionType, fromGqlInput: conditionFromGqlInput } = getConditionGqlType(buildToken, tailCollection.type)
           return [
-            formatName.queryByKeyMethod(tailCollection.name, relation.name),
+            formatName.queryRelationFieldByKeyMethod(tailCollection.name, relation.name),
             createConnectionGqlField<TValue, Condition, TTailValue>(buildToken, tailPaginator, {
               // The one input arg we have for this connection is the `condition` arg.
               inputArgEntries: [

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -1,6 +1,6 @@
 import { GraphQLObjectType, GraphQLFieldConfig, GraphQLNonNull, GraphQLID } from 'graphql'
 import { Collection, Condition, ObjectType, Relation, conditionHelpers } from '../../../interface'
-import { formatName, buildObject, idSerde } from '../../utils'
+import { buildObject, idSerde } from '../../utils'
 import getGqlOutputType from '../type/getGqlOutputType'
 import getNodeInterfaceType from '../node/getNodeInterfaceType'
 import createConnectionGqlField from '../connection/createConnectionGqlField'
@@ -19,6 +19,7 @@ export default function createCollectionGqlType<TValue> (
 ): GraphQLObjectType {
   const { options, inventory } = buildToken
   const { type, primaryKey } = collection
+  const formatName = buildToken.options.formatName
   const collectionTypeName = formatName.type(type.name)
 
   return new GraphQLObjectType({

--- a/src/graphql/schema/collection/createCollectionKeyInputHelpers.ts
+++ b/src/graphql/schema/collection/createCollectionKeyInputHelpers.ts
@@ -1,6 +1,6 @@
 import { GraphQLInputFieldConfig, GraphQLNonNull, getNullableType } from 'graphql'
 import { CollectionKey, Type, ObjectType, switchType } from '../../../interface'
-import { formatName, scrib } from '../../utils'
+import { scrib } from '../../utils'
 import getGqlInputType from '../type/getGqlInputType'
 import BuildToken from '../BuildToken'
 
@@ -24,6 +24,7 @@ export default function createCollectionKeyInputHelpers <TValue, TKey>(
   buildToken: BuildToken,
   collectionKey: CollectionKey<TValue, TKey>,
 ): CollectionKeyInputHelpers<TKey> {
+  const formatName = buildToken.options.formatName
   return switchType<CollectionKeyInputHelpers<TKey>>(collectionKey.keyType, {
     // If this is an object type, we want to flatten out the object’s fields into
     // field entries. This provides a nicer experience as it eliminates one level

--- a/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldConfig, GraphQLNonNull, GraphQLID } from 'graphql'
 import { Collection, CollectionKey, NullableType } from '../../../interface'
-import { formatName, idSerde, buildObject, scrib } from '../../utils'
+import { idSerde, buildObject, scrib } from '../../utils'
 import BuildToken from '../BuildToken'
 import getGqlOutputType from '../type/getGqlOutputType'
 import createConnectionGqlField from '../connection/createConnectionGqlField'
@@ -19,6 +19,7 @@ export default function createCollectionQueryFieldEntries <TValue>(
   const entries: Array<[string, GraphQLFieldConfig<never, never>]> = []
   const primaryKey = collection.primaryKey
   const paginator = collection.paginator
+  const formatName = buildToken.options.formatName
 
   // If the collection has a paginator, let’s use it to create a connection
   // field for our collection.

--- a/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
@@ -26,7 +26,7 @@ export default function createCollectionQueryFieldEntries <TValue>(
   if (paginator) {
     const { gqlType: gqlConditionType, fromGqlInput: conditionFromGqlInput } = getConditionGqlType(buildToken, type)
     entries.push([
-      formatName.field(`all-${collection.name}`),
+      formatName.queryAllMethod(collection.name),
       createConnectionGqlField(buildToken, paginator, {
         // The one input arg we have for this connection is the `condition` arg.
         inputArgEntries: [
@@ -51,7 +51,7 @@ export default function createCollectionQueryFieldEntries <TValue>(
 
     // If we got a field back, add it.
     if (field)
-      entries.push([formatName.field(type.name), field])
+      entries.push([formatName.queryMethod(type.name), field])
   }
 
   // Add a field to select any value in the collection by any key. So all
@@ -60,7 +60,7 @@ export default function createCollectionQueryFieldEntries <TValue>(
     const field = createCollectionKeyField(buildToken, collectionKey)
 
     // If we got a field back, add it.
-    if (field) entries.push([formatName.field(`${type.name}-by-${collectionKey.name}`), field])
+    if (field) entries.push([formatName.queryByKeyMethod(type.name, collectionKey.name), field])
   }
 
   return entries

--- a/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldConfig } from 'graphql'
 import { Collection, Relation, NullableType } from '../../../interface'
-import { formatName, scrib } from '../../utils'
+import { scrib } from '../../utils'
 import BuildToken from '../BuildToken'
 import getGqlOutputType from '../type/getGqlOutputType'
 
@@ -17,6 +17,7 @@ export default function createCollectionRelationTailGqlFieldEntries <TSource, TV
     getFieldName?: (relation: Relation<TValue, mixed, mixed>, collection: Collection<mixed>) => string,
   },
 ): Array<[string, GraphQLFieldConfig<TSource, mixed>]> {
+  const formatName = buildToken.options.formatName
   const { inventory } = buildToken
 
   // Some tests may choose to not include the inventory. If this is the case,

--- a/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
@@ -44,7 +44,7 @@ export default function createCollectionRelationTailGqlFieldEntries <TSource, TV
         return [
           options.getFieldName
             ? options.getFieldName(relation, collection)
-            : formatName.queryByKeyMethod(headCollection.type.name, relation.name),
+            : formatName.queryRelationFieldByKeyMethod(headCollection.type.name, relation.name),
           {
             description: `Reads a single ${scrib.type(headCollectionGqlType)} that is related to this ${scrib.type(collectionGqlType)}.`,
             type: headCollectionGqlType,

--- a/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
@@ -44,7 +44,7 @@ export default function createCollectionRelationTailGqlFieldEntries <TSource, TV
         return [
           options.getFieldName
             ? options.getFieldName(relation, collection)
-            : formatName.field(`${headCollection.type.name}-by-${relation.name}`),
+            : formatName.queryByKeyMethod(headCollection.type.name, relation.name),
           {
             description: `Reads a single ${scrib.type(headCollectionGqlType)} that is related to this ${scrib.type(collectionGqlType)}.`,
             type: headCollectionGqlType,

--- a/src/graphql/schema/collection/getConditionGqlType.ts
+++ b/src/graphql/schema/collection/getConditionGqlType.ts
@@ -35,7 +35,7 @@ function createConditionGqlType <TValue>(buildToken: BuildToken, type: ObjectTyp
 
   // Creates our GraphQL condition type.
   const gqlType = new GraphQLInputObjectType({
-    name: formatName.type(`${type.name}-condition`),
+    name: formatName.queryAllConditionType(type.name),
     description: `A condition to be used against \`${formatName.type(type.name)}\` object types. All fields are tested for equality and combined with a logical ‘and.’`,
     fields: buildObject<GraphQLInputFieldConfig>(gqlConditionFieldEntries),
   })

--- a/src/graphql/schema/collection/getConditionGqlType.ts
+++ b/src/graphql/schema/collection/getConditionGqlType.ts
@@ -1,6 +1,6 @@
 import { GraphQLInputObjectType, GraphQLInputFieldConfig } from 'graphql'
 import { Condition, conditionHelpers, NullableType, ObjectType } from '../../../interface'
-import { formatName, buildObject, memoize2 } from '../../utils'
+import { buildObject, memoize2 } from '../../utils'
 import getGqlInputType from '../type/getGqlInputType'
 import BuildToken from '../BuildToken'
 
@@ -10,6 +10,7 @@ function createConditionGqlType <TValue>(buildToken: BuildToken, type: ObjectTyp
   gqlType: GraphQLInputObjectType,
   fromGqlInput: (condition?: { [key: string]: mixed }) => Condition,
 } {
+  const formatName = buildToken.options.formatName
   // Creates the field entries for our paginator condition type.
   const gqlConditionFieldEntries =
     Array.from(type.fields).map(

--- a/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldConfig } from 'graphql'
 import { Collection, NullableType } from '../../../../interface'
-import { formatName, scrib } from '../../../utils'
+import { scrib } from '../../../utils'
 import BuildToken from '../../BuildToken'
 import getGqlInputType from '../../type/getGqlInputType'
 import getGqlOutputType from '../../type/getGqlOutputType'
@@ -21,6 +21,7 @@ export default function createCreateCollectionMutationFieldEntry <TValue>(
     return
 
   const name = `create-${collection.type.name}`
+  const formatName = buildToken.options.formatName
   const inputFieldName = formatName.field(collection.type.name)
   const { gqlType: inputGqlType, fromGqlInput: inputFromGqlInput } = getGqlInputType(buildToken, collection.type)
   const { gqlType: collectionGqlType } = getGqlOutputType(buildToken, new NullableType(collection.type))

--- a/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
@@ -20,13 +20,13 @@ export default function createCreateCollectionMutationFieldEntry <TValue>(
   if (!collection.create)
     return
 
-  const name = `create-${collection.type.name}`
   const formatName = buildToken.options.formatName
+  const name = formatName.createMethod(collection.type.name)
   const inputFieldName = formatName.field(collection.type.name)
   const { gqlType: inputGqlType, fromGqlInput: inputFromGqlInput } = getGqlInputType(buildToken, collection.type)
   const { gqlType: collectionGqlType } = getGqlOutputType(buildToken, new NullableType(collection.type))
 
-  return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
+  return [name, createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Creates a single ${scrib.type(collectionGqlType)}.`,
 
@@ -56,7 +56,7 @@ export default function createCreateCollectionMutationFieldEntry <TValue>(
       // Also Relay 1 requires us to return the edge.
       //
       // We may deprecate this in the future if Relay 2 doesn’t need it.
-      collection.paginator && [formatName.field(`${collection.type.name}-edge`), {
+      collection.paginator && [formatName.queryAllEdgeFieldName(collection.type.name), {
         description: `An edge for our ${scrib.type(collectionGqlType)}. May be used by Relay 1.`,
         type: getEdgeGqlType(buildToken, collection.paginator),
         args: { orderBy: createOrderByGqlArg(buildToken, collection.paginator) },

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
@@ -19,11 +19,11 @@ export default function createDeleteCollectionKeyMutationFieldEntry <TValue, TKe
     return
 
   const { collection } = collectionKey
-  const name = `delete-${collection.type.name}-by-${collectionKey.name}`
-  const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)
   const formatName = buildToken.options.formatName
+  const name = formatName.deleteByKeyMethod(collection.type.name, collectionKey.name)
+  const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)
 
-  return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
+  return [name, createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Deletes a single \`${formatName.type(collection.type.name)}\` using a unique key.`,
     inputFields: inputHelpers.fieldEntries,

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
@@ -1,6 +1,5 @@
 import { GraphQLFieldConfig } from 'graphql'
 import { CollectionKey } from '../../../../interface'
-import { formatName } from '../../../utils'
 import BuildToken from '../../BuildToken'
 import createMutationGqlField from '../../createMutationGqlField'
 import createCollectionKeyInputHelpers from '../createCollectionKeyInputHelpers'
@@ -22,6 +21,7 @@ export default function createDeleteCollectionKeyMutationFieldEntry <TValue, TKe
   const { collection } = collectionKey
   const name = `delete-${collection.type.name}-by-${collectionKey.name}`
   const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)
+  const formatName = buildToken.options.formatName
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
@@ -1,6 +1,6 @@
 import { GraphQLObjectType, GraphQLFieldConfig, GraphQLNonNull, GraphQLID } from 'graphql'
 import { Collection, NullableType } from '../../../../interface'
-import { formatName, idSerde, memoize2 } from '../../../utils'
+import { idSerde, memoize2 } from '../../../utils'
 import BuildToken from '../../BuildToken'
 import createMutationGqlField from '../../createMutationGqlField'
 import createMutationPayloadGqlType from '../../createMutationPayloadGqlType'
@@ -25,6 +25,7 @@ export default function createDeleteCollectionMutationFieldEntry <TValue>(
 
   const { options, inventory } = buildToken
   const name = `delete-${collection.type.name}`
+  const formatName = buildToken.options.formatName
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
@@ -61,6 +62,7 @@ function createDeleteCollectionPayloadGqlType <TValue>(
   collection: Collection<TValue>,
 ): GraphQLObjectType {
   const { primaryKey } = collection
+  const formatName = buildToken.options.formatName
   const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, new NullableType(collection.type))
   return createMutationPayloadGqlType<TValue>(buildToken, {
     name: `delete-${collection.type.name}`,

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
@@ -24,10 +24,10 @@ export default function createDeleteCollectionMutationFieldEntry <TValue>(
     return
 
   const { options, inventory } = buildToken
-  const name = `delete-${collection.type.name}`
   const formatName = buildToken.options.formatName
+  const name = formatName.deleteMethod(collection.type.name)
 
-  return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
+  return [name, createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Deletes a single \`${formatName.type(collection.type.name)}\` using its globally unique id.`,
     inputFields: [
@@ -65,7 +65,7 @@ function createDeleteCollectionPayloadGqlType <TValue>(
   const formatName = buildToken.options.formatName
   const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, new NullableType(collection.type))
   return createMutationPayloadGqlType<TValue>(buildToken, {
-    name: `delete-${collection.type.name}`,
+    name: formatName.deleteType(collection.type.name),
     outputFields: [
       // Add the deleted value as an output field so the user can see the
       // object they just deleted.
@@ -75,7 +75,7 @@ function createDeleteCollectionPayloadGqlType <TValue>(
       }],
       // Add the deleted values globally unique id as well. This one is
       // especially useful for removing old nodes from the cache.
-      primaryKey ? [formatName.field(`deleted-${collection.type.name}-id`), {
+      primaryKey ? [formatName.deletedID(collection.type.name), {
         type: GraphQLID,
         resolve: value => idSerde.serialize(collection, value),
       }] : null,

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
@@ -22,7 +22,7 @@ export default function createUpdateCollectionKeyMutationFieldEntry <TValue, TKe
   const { collection } = collectionKey
   const name = formatName.updateByKeyMethod(collection.type.name, collectionKey.name)
   const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)
-  const patchFieldName = formatName.updateFieldPatch(collection.type.name)
+  const patchFieldName = formatName.updatePatchField(collection.type.name)
   const { gqlType: patchGqlType, fromGqlInput: patchFromGqlInput } = getCollectionPatchType(buildToken, collection)
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
@@ -20,9 +20,9 @@ export default function createUpdateCollectionKeyMutationFieldEntry <TValue, TKe
 
   const formatName = buildToken.options.formatName
   const { collection } = collectionKey
-  const name = `update-${collection.type.name}-by-${collectionKey.name}`
+  const name = formatName.updateByKeyMethod(collection.type.name, collectionKey.name)
   const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)
-  const patchFieldName = formatName.field(`${collection.type.name}-patch`)
+  const patchFieldName = formatName.updateFieldPatch(collection.type.name)
   const { gqlType: patchGqlType, fromGqlInput: patchFromGqlInput } = getCollectionPatchType(buildToken, collection)
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
@@ -1,6 +1,5 @@
 import { GraphQLNonNull, GraphQLFieldConfig } from 'graphql'
 import { CollectionKey } from '../../../../interface'
-import { formatName } from '../../../utils'
 import BuildToken from '../../BuildToken'
 import createMutationGqlField from '../../createMutationGqlField'
 import createCollectionKeyInputHelpers from '../createCollectionKeyInputHelpers'
@@ -19,6 +18,7 @@ export default function createUpdateCollectionKeyMutationFieldEntry <TValue, TKe
   if (!collectionKey.update)
     return
 
+  const formatName = buildToken.options.formatName
   const { collection } = collectionKey
   const name = `update-${collection.type.name}-by-${collectionKey.name}`
   const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
@@ -7,7 +7,7 @@ import {
   GraphQLFieldConfig,
 } from 'graphql'
 import { Collection, NullableType } from '../../../../interface'
-import { formatName, buildObject, idSerde, memoize2 } from '../../../utils'
+import { buildObject, idSerde, memoize2 } from '../../../utils'
 import BuildToken from '../../BuildToken'
 import getGqlInputType from '../../type/getGqlInputType'
 import getGqlOutputType from '../../type/getGqlOutputType'
@@ -31,6 +31,7 @@ export default function createUpdateCollectionMutationFieldEntry <TValue>(
   if (!primaryKey || !primaryKey.update)
     return
 
+  const formatName = buildToken.options.formatName
   const { options, inventory } = buildToken
   const name = `update-${collection.type.name}`
   const patchFieldName = formatName.field(`${collection.type.name}-patch`)
@@ -87,6 +88,7 @@ function createCollectionPatchType <TValue>(buildToken: BuildToken, collection: 
 } {
   const { type } = collection
 
+  const formatName = buildToken.options.formatName
   const fields =
     Array.from(type.fields).map(([fieldName, field]) => {
       const { gqlType, fromGqlInput } = getGqlInputType(buildToken, new NullableType(field.type))
@@ -134,6 +136,7 @@ function createUpdateCollectionPayloadGqlType <TValue>(
   buildToken: BuildToken,
   collection: Collection<TValue>,
 ): GraphQLObjectType {
+  const formatName = buildToken.options.formatName
   const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, new NullableType(collection.type))
   return createMutationPayloadGqlType<TValue>(buildToken, {
     name: `update-${collection.type.name}`,

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
@@ -34,7 +34,7 @@ export default function createUpdateCollectionMutationFieldEntry <TValue>(
   const formatName = buildToken.options.formatName
   const { options, inventory } = buildToken
   const name = formatName.updateMethod(collection.type.name)
-  const patchFieldName = formatName.updateFieldPatch(collection.type.name)
+  const patchFieldName = formatName.updatePatchField(collection.type.name)
   const { gqlType: patchGqlType, fromGqlInput: patchFromGqlInput } = getCollectionPatchType(buildToken, collection)
 
   return [name, createMutationGqlField<TValue>(buildToken, {
@@ -105,7 +105,7 @@ function createCollectionPatchType <TValue>(buildToken: BuildToken, collection: 
 
   return {
     gqlType: new GraphQLInputObjectType({
-      name: formatName.type(`${type.name}-patch`),
+      name: formatName.updatePatchType(type.name),
       description: `Represents an update to a \`${formatName.type(type.name)}\`. Fields that are set will be updated.`,
       fields: () => buildObject<GraphQLInputFieldConfig>(fields),
     }),

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
@@ -33,11 +33,11 @@ export default function createUpdateCollectionMutationFieldEntry <TValue>(
 
   const formatName = buildToken.options.formatName
   const { options, inventory } = buildToken
-  const name = `update-${collection.type.name}`
-  const patchFieldName = formatName.field(`${collection.type.name}-patch`)
+  const name = formatName.updateMethod(collection.type.name)
+  const patchFieldName = formatName.updateFieldPatch(collection.type.name)
   const { gqlType: patchGqlType, fromGqlInput: patchFromGqlInput } = getCollectionPatchType(buildToken, collection)
 
-  return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
+  return [name, createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Updates a single \`${formatName.type(collection.type.name)}\` using its globally unique id and a patch.`,
     inputFields: [
@@ -139,7 +139,7 @@ function createUpdateCollectionPayloadGqlType <TValue>(
   const formatName = buildToken.options.formatName
   const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, new NullableType(collection.type))
   return createMutationPayloadGqlType<TValue>(buildToken, {
-    name: `update-${collection.type.name}`,
+    name: formatName.updateType(collection.type.name),
     outputFields: [
       // Add the updated value as an output field so the user can see the
       // object they just updated.

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -12,7 +12,7 @@ import {
   Kind,
 } from 'graphql'
 import { Paginator } from '../../../interface'
-import { buildObject, formatName, memoize2, scrib } from '../../utils'
+import { buildObject, memoize2, scrib } from '../../utils'
 import getGqlOutputType from '../type/getGqlOutputType'
 import BuildToken from '../BuildToken'
 
@@ -137,6 +137,7 @@ export function _createConnectionGqlType <TInput, TItemValue>(
 ): GraphQLObjectType {
   const { gqlType } = getGqlOutputType(buildToken, paginator.itemType)
   const gqlEdgeType = getEdgeGqlType(buildToken, paginator)
+  const formatName = buildToken.options.formatName
 
   return new GraphQLObjectType({
     name: formatName.type(`${paginator.name}-connection`),
@@ -178,6 +179,7 @@ export function _createEdgeGqlType <TInput, TItemValue>(
   buildToken: BuildToken,
   paginator: Paginator<TInput, TItemValue>,
 ): GraphQLObjectType {
+  const formatName = buildToken.options.formatName
   const { gqlType } = getGqlOutputType(buildToken, paginator.itemType)
 
   return new GraphQLObjectType({
@@ -237,6 +239,7 @@ export function _createOrderByGqlEnumType <TInput, TItemValue>(
   paginator: Paginator<TInput, TItemValue>,
 ): GraphQLEnumType {
   const { gqlType } = getGqlOutputType(buildToken, paginator.itemType)
+  const formatName = buildToken.options.formatName
 
   return new GraphQLEnumType({
     name: formatName.type(`${paginator.name}-order-by`),

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -140,7 +140,7 @@ export function _createConnectionGqlType <TInput, TItemValue>(
   const formatName = buildToken.options.formatName
 
   return new GraphQLObjectType({
-    name: formatName.type(`${paginator.name}-connection`),
+    name: formatName.queryAllRelationType(paginator.name),
     description: `A connection to a list of ${scrib.type(gqlType)} values.`,
     fields: () => ({
       pageInfo: {
@@ -183,7 +183,7 @@ export function _createEdgeGqlType <TInput, TItemValue>(
   const { gqlType } = getGqlOutputType(buildToken, paginator.itemType)
 
   return new GraphQLObjectType({
-    name: formatName.type(`${paginator.name}-edge`),
+    name: formatName.queryAllEdgeType(paginator.name),
     description: `A ${scrib.type(gqlType)} edge in the connection.`,
     fields: () => ({
       cursor: {
@@ -242,7 +242,7 @@ export function _createOrderByGqlEnumType <TInput, TItemValue>(
   const formatName = buildToken.options.formatName
 
   return new GraphQLEnumType({
-    name: formatName.type(`${paginator.name}-order-by`),
+    name: formatName.queryAllOrderByType(paginator.name),
     description: `Methods to use when ordering ${scrib.type(gqlType)}.`,
     values: buildObject(
       Array.from(paginator.orderings)

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -1,5 +1,7 @@
 import { GraphQLSchema } from 'graphql'
 import { Inventory } from '../../interface'
+import FormatName from './FormatName'
+import formatName from '../utils/formatName'
 import BuildToken, { _BuildTokenHooks, _BuildTokenTypeOverrides } from './BuildToken'
 import getQueryGqlType from './getQueryGqlType'
 import getMutationGqlType from './getMutationGqlType'
@@ -15,12 +17,16 @@ export type SchemaOptions = {
   // If true then the default mutations for tables (e.g. createMyTable) will
   // not be created
   disableDefaultMutations?: boolean,
+  // Allows hiding primary keys from the API
+  primaryKeyAPI?: boolean,
   // Some hooks to allow extension of the schema. Currently this API is
   // private. Use at your own risk.
   _hooks?: _BuildTokenHooks,
   // GraphQL types that override the default type generation. Currently this
   // API is private. Use at your own risk.
   _typeOverrides?: _BuildTokenTypeOverrides,
+  // Formatting of names for requests, properties, etc.
+  formatName?: FormatName,
 }
 
 /**
@@ -37,6 +43,7 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
       nodeIdFieldName: options.nodeIdFieldName || '__id',
       dynamicJson: options.dynamicJson || false,
       disableDefaultMutations: options.disableDefaultMutations || false,
+      formatName: options.formatName || formatName,
     },
     _hooks: options._hooks || {},
     _typeOverrides: options._typeOverrides || new Map(),

--- a/src/graphql/schema/createMutationGqlField.ts
+++ b/src/graphql/schema/createMutationGqlField.ts
@@ -6,7 +6,7 @@ import {
   GraphQLInputObjectType,
   GraphQLInputFieldConfig,
 } from 'graphql'
-import { formatName, buildObject } from '../utils'
+import { buildObject } from '../utils'
 import BuildToken from './BuildToken'
 import createMutationPayloadGqlType from './createMutationPayloadGqlType'
 
@@ -48,6 +48,7 @@ export default function createMutationGqlField <T>(
 ): GraphQLFieldConfig<mixed, MutationValue<T>> {
   if (config.outputFields && config.payloadType)
     throw new Error('Mutation `outputFields` and `payloadType` may not be defiend at the same time.')
+  const formatName = buildToken.options.formatName
 
   return {
     description: config.description,

--- a/src/graphql/schema/createMutationGqlField.ts
+++ b/src/graphql/schema/createMutationGqlField.ts
@@ -61,7 +61,7 @@ export default function createMutationGqlField <T>(
       input: {
         description: 'The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.',
         type: new GraphQLNonNull(new GraphQLInputObjectType({
-          name: formatName.type(`${config.name}-input`),
+          name: formatName.inputType(config.name),
           description: `All input for the \`${formatName.field(config.name)}\` mutation.`,
           fields: buildObject<GraphQLInputFieldConfig>(
             [

--- a/src/graphql/schema/createMutationGqlField.ts
+++ b/src/graphql/schema/createMutationGqlField.ts
@@ -61,7 +61,7 @@ export default function createMutationGqlField <T>(
       input: {
         description: 'The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.',
         type: new GraphQLNonNull(new GraphQLInputObjectType({
-          name: formatName.inputType(config.name),
+          name: formatName.createType(config.name),
           description: `All input for the \`${formatName.field(config.name)}\` mutation.`,
           fields: buildObject<GraphQLInputFieldConfig>(
             [

--- a/src/graphql/schema/createMutationPayloadGqlType.ts
+++ b/src/graphql/schema/createMutationPayloadGqlType.ts
@@ -17,7 +17,7 @@ export default function createMutationPayloadGqlType <TValue>(
 ): GraphQLObjectType {
   const formatName = buildToken.options.formatName
   return new GraphQLObjectType({
-    name: formatName.type(`${config.name}-payload`),
+    name: formatName.mutationPayload(config.name),
     description: `The output of our \`${formatName.field(config.name)}\` mutation.`,
     fields: buildObject<GraphQLFieldConfig<MutationValue<TValue>, mixed>>(
       [

--- a/src/graphql/schema/createMutationPayloadGqlType.ts
+++ b/src/graphql/schema/createMutationPayloadGqlType.ts
@@ -1,5 +1,5 @@
 import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from 'graphql'
-import { formatName, buildObject } from '../utils'
+import { buildObject } from '../utils'
 import BuildToken from './BuildToken'
 import { MutationValue } from './createMutationGqlField'
 import getQueryGqlType, { $$isQuery } from './getQueryGqlType'
@@ -15,6 +15,7 @@ export default function createMutationPayloadGqlType <TValue>(
     outputFields?: Array<[string, GraphQLFieldConfig<TValue, mixed>] | false | null | undefined>,
   },
 ): GraphQLObjectType {
+  const formatName = buildToken.options.formatName
   return new GraphQLObjectType({
     name: formatName.type(`${config.name}-payload`),
     description: `The output of our \`${formatName.field(config.name)}\` mutation.`,

--- a/src/graphql/schema/type/getGqlInputType.ts
+++ b/src/graphql/schema/type/getGqlInputType.ts
@@ -204,7 +204,13 @@ export default function getGqlInputType <TValue>(buildToken: BuildToken, type: T
   // If we have an input type override for this type, throw an error because
   // that is not yet implemented!
   if (buildToken._typeOverrides) {
-    const typeOverride = buildToken._typeOverrides.get(type)
+    const typeOverrideRaw = buildToken._typeOverrides.get(type)
+    let typeOverride
+    if (typeof typeOverrideRaw === 'function') {
+      typeOverride = typeOverrideRaw(buildToken)
+    } else {
+      typeOverride = typeOverrideRaw
+    }
     if (typeOverride && typeOverride.input)
       throw new Error(`Unimplemented, cannot create an input type for '${getNamedType(type).name}'.`)
   }

--- a/src/graphql/schema/type/getGqlOutputType.ts
+++ b/src/graphql/schema/type/getGqlOutputType.ts
@@ -228,7 +228,13 @@ export default function getGqlOutputType <TValue>(buildToken: BuildToken, type: 
   // before we call our actual type function. We will automatically define the
   // coercer as an identity function.
   if (buildToken._typeOverrides) {
-    const typeOverride = buildToken._typeOverrides.get(type)
+    const typeOverrideRaw = buildToken._typeOverrides.get(type)
+    let typeOverride
+    if (typeof typeOverrideRaw === 'function') {
+      typeOverride = typeOverrideRaw(buildToken)
+    } else {
+      typeOverride = typeOverrideRaw
+    }
     if (typeOverride && typeOverride.output)
       return { gqlType: typeOverride.output, intoGqlOutput: value => value }
   }

--- a/src/graphql/utils/__tests__/formatName-test.ts
+++ b/src/graphql/utils/__tests__/formatName-test.ts
@@ -1,4 +1,4 @@
-import formatName from '../formatName'
+import formatName from '../formats/default'
 
 test('type will format in pascal case', () => {
   expect(formatName.type('hello_world')).toBe('HelloWorld')

--- a/src/graphql/utils/formatName.ts
+++ b/src/graphql/utils/formatName.ts
@@ -1,4 +1,5 @@
 import { camelCase, pascalCase, constantCase } from 'change-case'
+import FormatName from '../schema/FormatName'
 
 const formatInsideUnderscores = (formatter: (name: string) => string) => (fullName: string) => {
   const [, start, name, finish] = /^(_*)(.*?)(_*)$/.exec(fullName)!
@@ -9,26 +10,38 @@ const camelCaseInsideUnderscores = formatInsideUnderscores(name => camelCase(nam
 const pascalCaseInsideUnderscores = formatInsideUnderscores(name => pascalCase(name, undefined, true))
 const constantCaseInsideUnderscores = formatInsideUnderscores(constantCase)
 
-namespace formatName {
-  /**
-   * Formats a GraphQL type name using PascalCase.
-   */
-  export const type = pascalCaseInsideUnderscores
+const formatName: FormatName = {
+  type: pascalCaseInsideUnderscores,
+  field: camelCaseInsideUnderscores,
+  arg: camelCaseInsideUnderscores,
+  enumValue: constantCaseInsideUnderscores,
 
-  /**
-   * Formats a GraphQL field name using camelCase.
-   */
-  export const field = camelCaseInsideUnderscores
+  queryAllMethod: (collectionType: string): string => camelCaseInsideUnderscores(`all_${collectionType}`),
+  queryAllOrderByType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_order_by`),
+  queryAllEdgeType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_edge`),
+  queryAllRelationType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_connection`),
+  queryAllConditionType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_condition`),
+  queryAllEdgeFieldName: (collectionType: string): string =>  camelCaseInsideUnderscores(`${collectionType}_edge`),
 
-  /**
-   * Formats a GraphQL argument name using camelCase.
-   */
-  export const arg = camelCaseInsideUnderscores
+  queryMethod: camelCaseInsideUnderscores,
+  queryByKeyMethod: (collectionType: string, key: string): string =>  camelCaseInsideUnderscores(`${collectionType}_by_${key}`),
 
-  /**
-   * Formats a GraphQL enum value name using CONSTANT_CASE.
-   */
-  export const enumValue = constantCaseInsideUnderscores
+  deleteMethod: (collectionType: string): string => camelCaseInsideUnderscores(`delete_${collectionType}`),
+  deleteType: (collectionType: string): string => pascalCaseInsideUnderscores(`delete_${collectionType}`),
+  deleteByKeyMethod: (collectionType: string, key: string): string =>  camelCase(`delete_${collectionType}_by_${key}`),
+  deletedID: (collectionType: string): string =>  camelCaseInsideUnderscores(`deleted_${collectionType}_id`),
+
+  inputType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_input`),
+
+  mutationPayload: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_payload`),
+
+  createMethod: (collectionType: string): string => camelCaseInsideUnderscores(`create_${collectionType}`),
+
+  updateMethod: (fieldName: string): string => camelCaseInsideUnderscores(`update_${fieldName}`),
+  updateType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`update_${collectionType}`),
+  updateByKeyMethod: (collectionType: string, key: string): string =>  pascalCaseInsideUnderscores(`update_${collectionType}_by_${key}`),
+  updatePatchyType: (collectionType: string): string => pascalCaseInsideUnderscores(`${collectionType}_patch`),
+  updateFieldPatch: (fieldName: string): string => camelCaseInsideUnderscores(`${fieldName}_patch`),
 }
 
 export default formatName

--- a/src/graphql/utils/formats/default.ts
+++ b/src/graphql/utils/formats/default.ts
@@ -1,0 +1,48 @@
+import { camelCase, pascalCase, constantCase } from 'change-case'
+import FormatName from '../../schema/FormatName'
+
+const formatInsideUnderscores = (formatter: (name: string) => string) => (fullName: string) => {
+  const [, start, name, finish] = /^(_*)(.*?)(_*)$/.exec(fullName)!
+  return `${start}${formatter(name)}${finish}`
+}
+
+const camelCaseInsideUnderscores = formatInsideUnderscores(name => camelCase(name, undefined, true))
+const pascalCaseInsideUnderscores = formatInsideUnderscores(name => pascalCase(name, undefined, true))
+const constantCaseInsideUnderscores = formatInsideUnderscores(constantCase)
+
+const formatName: FormatName = {
+  type: pascalCaseInsideUnderscores,
+  field: camelCaseInsideUnderscores,
+  arg: camelCaseInsideUnderscores,
+  enumValue: constantCaseInsideUnderscores,
+
+  queryAllMethod: (collectionType: string): string => camelCaseInsideUnderscores(`all_${collectionType}`),
+  queryAllOrderByType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_order_by`),
+  queryAllEdgeType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_edge`),
+  queryAllRelationType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_connection`),
+  queryAllConditionType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_condition`),
+  queryAllEdgeFieldName: (collectionType: string): string =>  camelCaseInsideUnderscores(`${collectionType}_edge`),
+
+  queryMethod: camelCaseInsideUnderscores,
+  queryByKeyMethod: (collectionType: string, key: string): string => camelCaseInsideUnderscores(`${collectionType}_by_${key}`),
+  queryRelationField: camelCaseInsideUnderscores,
+  queryRelationFieldByKeyMethod: (collectionType: string, key: string): string => camelCaseInsideUnderscores(`${collectionType}_by_${key}`),
+
+  deleteMethod: (collectionType: string): string => camelCaseInsideUnderscores(`delete_${collectionType}`),
+  deleteType: (collectionType: string): string => pascalCaseInsideUnderscores(`delete_${collectionType}`),
+  deleteByKeyMethod: (collectionType: string, key: string): string =>  camelCase(`delete_${collectionType}_by_${key}`),
+  deletedID: (collectionType: string): string =>  camelCaseInsideUnderscores(`deleted_${collectionType}_id`),
+
+  mutationPayload: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_payload`),
+
+  createType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_input`),
+  createMethod: (collectionType: string): string => camelCaseInsideUnderscores(`create_${collectionType}`),
+
+  updateMethod: (fieldName: string): string => camelCaseInsideUnderscores(`update_${fieldName}`),
+  updateType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`update_${collectionType}`),
+  updateByKeyMethod: (collectionType: string, key: string): string =>  pascalCaseInsideUnderscores(`update_${collectionType}_by_${key}`),
+  updatePatchType: (collectionType: string): string => pascalCaseInsideUnderscores(`${collectionType}-patch`),
+  updatePatchField: (fieldName: string): string => camelCaseInsideUnderscores(`${fieldName}_patch`),
+}
+
+export default formatName

--- a/src/graphql/utils/formats/scaphold.ts
+++ b/src/graphql/utils/formats/scaphold.ts
@@ -1,5 +1,5 @@
 import { camelCase, pascalCase, constantCase } from 'change-case'
-import FormatName from '../schema/FormatName'
+import FormatName from '../../schema/FormatName'
 
 const formatInsideUnderscores = (formatter: (name: string) => string) => (fullName: string) => {
   const [, start, name, finish] = /^(_*)(.*?)(_*)$/.exec(fullName)!
@@ -23,25 +23,26 @@ const formatName: FormatName = {
   queryAllConditionType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_condition`),
   queryAllEdgeFieldName: (collectionType: string): string =>  camelCaseInsideUnderscores(`${collectionType}_edge`),
 
-  queryMethod: camelCaseInsideUnderscores,
-  queryByKeyMethod: (collectionType: string, key: string): string =>  camelCaseInsideUnderscores(`${collectionType}_by_${key}`),
+  queryMethod: (collectionType: string): string => camelCaseInsideUnderscores(`get_${collectionType}`),
+  queryByKeyMethod: (collectionType: string, key: string): string => camelCaseInsideUnderscores(`get_${collectionType}_by_${key}`),
+  queryRelationField: camelCaseInsideUnderscores,
+  queryRelationFieldByKeyMethod: (collectionType: string, key: string): string => camelCaseInsideUnderscores(`${collectionType}_by_${key}`),
 
   deleteMethod: (collectionType: string): string => camelCaseInsideUnderscores(`delete_${collectionType}`),
   deleteType: (collectionType: string): string => pascalCaseInsideUnderscores(`delete_${collectionType}`),
   deleteByKeyMethod: (collectionType: string, key: string): string =>  camelCase(`delete_${collectionType}_by_${key}`),
   deletedID: (collectionType: string): string =>  camelCaseInsideUnderscores(`deleted_${collectionType}_id`),
 
-  inputType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_input`),
-
   mutationPayload: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_payload`),
 
+  createType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`${collectionType}_input`),
   createMethod: (collectionType: string): string => camelCaseInsideUnderscores(`create_${collectionType}`),
 
   updateMethod: (fieldName: string): string => camelCaseInsideUnderscores(`update_${fieldName}`),
   updateType: (collectionType: string): string =>  pascalCaseInsideUnderscores(`update_${collectionType}`),
   updateByKeyMethod: (collectionType: string, key: string): string =>  pascalCaseInsideUnderscores(`update_${collectionType}_by_${key}`),
-  updatePatchyType: (collectionType: string): string => pascalCaseInsideUnderscores(`${collectionType}_patch`),
-  updateFieldPatch: (fieldName: string): string => camelCaseInsideUnderscores(`${fieldName}_patch`),
+  updatePatchType: (collectionType: string): string => pascalCaseInsideUnderscores(`${collectionType}_patch`),
+  updatePatchField: (fieldName: string): string => camelCaseInsideUnderscores(`${fieldName}_patch`),
 }
 
 export default formatName

--- a/src/graphql/utils/index.ts
+++ b/src/graphql/utils/index.ts
@@ -1,9 +1,9 @@
 import buildObject from './buildObject'
-import formatName from './formatName'
+import defaultFormat from './formats/default'
 import idSerde from './idSerde'
 import scrib from './scrib'
 import parseGqlLiteralToValue from './parseGqlLiteralToValue'
 
-export { buildObject, formatName, idSerde, scrib, parseGqlLiteralToValue }
+export { buildObject, defaultFormat as formatName, idSerde, scrib, parseGqlLiteralToValue }
 
 export * from './memoize'

--- a/src/postgraphql/schema/auth/getJwtGqlType.ts
+++ b/src/postgraphql/schema/auth/getJwtGqlType.ts
@@ -1,23 +1,25 @@
 import { sign as signJwt } from 'jsonwebtoken'
 import { GraphQLScalarType } from 'graphql'
 import { ObjectType } from '../../../interface'
-import { formatName, memoize2 } from '../../../graphql/utils'
+import { memoize3 } from '../../../graphql/utils'
+import BuildToken from '../../../graphql/schema/BuildToken'
 
-const _getJwtGqlType = memoize2(_createJwtGqlType)
+const _getJwtGqlType = memoize3(_createJwtGqlType)
 
 /**
  * Gets a JWT GraphQL scalar type from an object type. Every time this type is
  * serialized, a new token will be signed.
  */
-function getJwtGqlType <TValue>(type: ObjectType<TValue>, jwtSecret: string): GraphQLScalarType {
-  return _getJwtGqlType(type, jwtSecret)
+function getJwtGqlType <TValue>(buildToken: BuildToken, type: ObjectType<TValue>, jwtSecret: string): GraphQLScalarType {
+  return _getJwtGqlType(buildToken, type, jwtSecret)
 }
 
 export default getJwtGqlType
 
 // TODO: Can we make a type that represents an object type possible wrapped in
 // nullable types? We really need to improve the types for our type system...
-export function _createJwtGqlType <TValue>(type: ObjectType<TValue>, jwtSecret: string): GraphQLScalarType {
+export function _createJwtGqlType <TValue>(buildToken: BuildToken, type: ObjectType<TValue>, jwtSecret: string): GraphQLScalarType {
+  const formatName = buildToken.options.formatName
   return new GraphQLScalarType({
     name: formatName.type(type.name),
     description:

--- a/src/postgraphql/schema/createPostGraphQLSchema.ts
+++ b/src/postgraphql/schema/createPostGraphQLSchema.ts
@@ -113,12 +113,12 @@ export default async function createPostGraphQLSchema (
     // If we have a JWT Postgres type, let us override the GraphQL output type
     // with our own.
     _typeOverrides: jwtPgType && new Map<Type<mixed>, { input?: true, output?: GraphQLOutputType }>([
-      [getTypeFromPgType(pgCatalog, jwtPgType), {
+      [getTypeFromPgType(pgCatalog, jwtPgType), (buildToken: BuildToken) => ({
         // Throw an error if the user tries to use this as input.
         get input (): never { throw new Error(`Using the JWT Token type '${options.jwtPgTypeIdentifier}' as input is not yet implemented.`) },
         // Use our JWT GraphQL type as the output.
-        output: getJwtGqlType(getNonNullableType(getTypeFromPgType(pgCatalog, jwtPgType)) as PgClassType, options.jwtSecret!),
-      }],
+        output: getJwtGqlType(buildToken, getNonNullableType(getTypeFromPgType(pgCatalog, jwtPgType)) as PgClassType, options.jwtSecret!),
+      })],
     ]),
 
     _hooks: {

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -77,7 +77,7 @@ export default function createPgProcedureMutationGqlFieldEntry (
       // Also Relay 1 requires us to return the edge.
       //
       // We may deprecate this in the future if Relay 2 doesn’t need it.
-      pgCollection && pgCollection.paginator && [formatName.field(`${pgCollection.type.name}-edge`), {
+      pgCollection && pgCollection.paginator && [formatName.queryAllEdgeFieldName(pgCollection.type.name), {
         description: `An edge for the type. May be used by Relay 1.`,
         type: getEdgeGqlType(buildToken, pgCollection.paginator),
         args: { orderBy: createOrderByGqlArg(buildToken, pgCollection.paginator) },

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -7,7 +7,6 @@ import {
   getNullableType,
 } from 'graphql'
 import { Type, switchType } from '../../../interface'
-import { formatName } from '../../../graphql/utils'
 import BuildToken from '../../../graphql/schema/BuildToken'
 import createMutationGqlField from '../../../graphql/schema/createMutationGqlField'
 import createCollectionRelationTailGqlFieldEntries from '../../../graphql/schema/collection/createCollectionRelationTailGqlFieldEntries'
@@ -31,6 +30,7 @@ export default function createPgProcedureMutationGqlFieldEntry (
 ): [string, GraphQLFieldConfig<mixed, mixed>] {
   const { inventory } = buildToken
   const fixtures = createPgProcedureFixtures(buildToken, pgCatalog, pgProcedure)
+  const formatName = buildToken.options.formatName
 
   // See if the output type of this procedure is a single object, try to find a
   // `PgCollection` which has the same type. If it exists we add some extra

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -1,5 +1,5 @@
 import { GraphQLNonNull, GraphQLFieldConfig, GraphQLArgumentConfig, getNullableType } from 'graphql'
-import { formatName, buildObject } from '../../../graphql/utils'
+import { buildObject } from '../../../graphql/utils'
 import BuildToken from '../../../graphql/schema/BuildToken'
 import createConnectionGqlField from '../../../graphql/schema/connection/createConnectionGqlField'
 import { sql } from '../../../postgres/utils'
@@ -38,6 +38,7 @@ function createPgSingleProcedureQueryGqlFieldEntry (
   pgProcedure: PgCatalogProcedure,
 ): [string, GraphQLFieldConfig<mixed, mixed>] {
   const fixtures = createPgProcedureFixtures(buildToken, pgCatalog, pgProcedure)
+  const formatName = buildToken.options.formatName
 
   // Create our GraphQL input fields users will use to input data into our
   // procedure.
@@ -76,6 +77,7 @@ function createPgSetProcedureQueryGqlFieldEntry (
 ): [string, GraphQLFieldConfig<mixed, mixed>] {
   const fixtures = createPgProcedureFixtures(buildToken, pgCatalog, pgProcedure)
   const paginator = new PgProcedurePaginator(fixtures)
+  const formatName = buildToken.options.formatName
 
   // Create our GraphQL input fields users will use to input data into our
   // procedure.

--- a/src/postgraphql/schema/procedures/createPgProcedureQueryGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureQueryGqlFieldEntry.ts
@@ -1,5 +1,5 @@
 import { GraphQLNonNull, GraphQLFieldConfig, GraphQLArgumentConfig, getNullableType } from 'graphql'
-import { formatName, buildObject } from '../../../graphql/utils'
+import { buildObject } from '../../../graphql/utils'
 import BuildToken from '../../../graphql/schema/BuildToken'
 import createConnectionGqlField from '../../../graphql/schema/connection/createConnectionGqlField'
 import { sql } from '../../../postgres/utils'
@@ -35,6 +35,7 @@ function createPgSingleProcedureQueryGqlFieldEntry (
   pgProcedure: PgCatalogProcedure,
 ): [string, GraphQLFieldConfig<mixed, mixed>] {
   const fixtures = createPgProcedureFixtures(buildToken, pgCatalog, pgProcedure)
+  const formatName = buildToken.options.formatName
 
   // Create our GraphQL input fields users will use to input data into our
   // procedure.
@@ -72,6 +73,7 @@ function createPgSetProcedureQueryGqlFieldEntry (
 ): [string, GraphQLFieldConfig<mixed, mixed>] {
   const fixtures = createPgProcedureFixtures(buildToken, pgCatalog, pgProcedure)
   const paginator = new PgProcedurePaginator(fixtures)
+  const formatName = buildToken.options.formatName
 
   // Create our GraphQL input fields users will use to input data into our
   // procedure.


### PR DESCRIPTION
_Disclaimer: I have been working on this but I am not sure if it is ready for action yet, sharing in advance to test the waters_

The names for fields and types are different in various graphql databases like reindex or scaphold. This PR extends `formatNames` to have fields for all the usages in order to be able to replace them to be compatible in order for using postgraphql when moving from/to one of those databases.