### PR TITLE
WIP: Reduce the number of SQL queries

### DIFF
--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -37,7 +37,7 @@ export default function createCollectionGqlType<TValue> (
         primaryKey && [options.nodeIdFieldName, {
           description: 'A globally unique identifier. Can be used in various places throughout the system to identify this single value.',
           type: new GraphQLNonNull(GraphQLID),
-          externalFieldNameDependencies: primaryKey._keyTypeFields.map(([fieldName, field]) => fieldName),
+          externalFieldNameDependencies: primaryKey._keyTypeFields.map(([fieldName, field]) => field.externalFieldName),
           resolve: (value: TValue) => idSerde.serialize(collection, value),
         }],
       ],
@@ -51,7 +51,7 @@ export default function createCollectionGqlType<TValue> (
             value: {
               description: field.description,
               type: gqlType,
-              externalFieldName: fieldName,
+              externalFieldName: field.externalFieldName,
               resolve: (value: TValue): mixed => intoGqlOutput(field.getValue(value)),
             },
           }

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -7,6 +7,7 @@ import createConnectionGqlField from '../connection/createConnectionGqlField'
 import BuildToken from '../BuildToken'
 import createCollectionRelationTailGqlFieldEntries from './createCollectionRelationTailGqlFieldEntries'
 import getConditionGqlType from './getConditionGqlType'
+import { isSymbol } from 'lodash'
 
 /**
  * Creates the output object type for a collection. This type will include all
@@ -95,9 +96,11 @@ export default function createCollectionGqlType<TValue> (
               ],
               // We use the config when creating a connection field to inject
               // a condition that limits what we select from the paginator.
-              getPaginatorInput: (aliasIdentifier: mixed, args: { condition?: { [key: string]: mixed } }) =>
+              getPaginatorInput: (sourceOrAliasIdentifier: mixed, args: { condition?: { [key: string]: mixed } }) =>
                 conditionHelpers.and(
-                  relation.getTailConditionFromHeadAlias!(aliasIdentifier),
+                  isSymbol(sourceOrAliasIdentifier)
+                    ? relation.getTailConditionFromHeadAlias!(sourceOrAliasIdentifier)
+                    : relation.getTailConditionFromHeadValue!(sourceOrAliasIdentifier),
                   conditionFromGqlInput(args.condition),
                 ),
               subquery: true,

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -100,7 +100,9 @@ export default function createCollectionGqlType<TValue> (
                   relation.getTailConditionFromHeadAlias!(aliasIdentifier),
                   conditionFromGqlInput(args.condition),
                 ),
-            }, true),
+              subquery: true,
+              relation,
+            }),
           ]
         }),
     ),

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -52,8 +52,7 @@ export default function createCollectionGqlType<TValue> (
             value: {
               description: field.description,
               type: gqlType,
-              sqlName: () => fieldName,
-              sqlField: fieldName,
+              externalFieldName: fieldName,
               resolve: (value) => {
                 return value.get(fieldName)
               }

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -37,6 +37,7 @@ export default function createCollectionGqlType<TValue> (
         primaryKey && [options.nodeIdFieldName, {
           description: 'A globally unique identifier. Can be used in various places throughout the system to identify this single value.',
           type: new GraphQLNonNull(GraphQLID),
+          externalFieldNameDependencies: primaryKey._keyTypeFields.map(([fieldName, field]) => fieldName),
           resolve: (value: TValue) => idSerde.serialize(collection, value),
         }],
       ],

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -99,12 +99,12 @@ export default function createCollectionGqlType<TValue> (
               ],
               // We use the config when creating a connection field to inject
               // a condition that limits what we select from the paginator.
-              getPaginatorInput: (headValue: TValue, args: { condition?: { [key: string]: mixed } }) =>
+              getPaginatorInput: (aliasIdentifier: mixed, args: { condition?: { [key: string]: mixed } }) =>
                 conditionHelpers.and(
-                  relation.getTailConditionFromHeadValue!(headValue),
+                  relation.getTailConditionFromHeadAlias!(aliasIdentifier),
                   conditionFromGqlInput(args.condition),
                 ),
-            }),
+            }, true),
           ]
         }),
     ),

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -53,7 +53,7 @@ export default function createCollectionGqlType<TValue> (
               description: field.description,
               type: gqlType,
               sqlName: () => fieldName,
-              sqlExpression: (aliasIdentifier) => sql.query`${sql.identifier(aliasIdentifier)}.${sql.identifier(fieldName)}`,
+              sqlField: fieldName,
               resolve: (value) => {
                 return value.get(fieldName)
               }

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -7,7 +7,6 @@ import createConnectionGqlField from '../connection/createConnectionGqlField'
 import BuildToken from '../BuildToken'
 import createCollectionRelationTailGqlFieldEntries from './createCollectionRelationTailGqlFieldEntries'
 import getConditionGqlType from './getConditionGqlType'
-import { sql } from '../../../postgres/utils'
 
 /**
  * Creates the output object type for a collection. This type will include all
@@ -46,14 +45,13 @@ export default function createCollectionGqlType<TValue> (
       Array.from(type.fields).map(
         <TFieldValue>([fieldName, field]: [string, ObjectType.Field<TValue, TFieldValue>]) => {
           const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, field.type)
-          const formattedFieldName = formatName.field(fieldName)
           return {
-            key: formattedFieldName,
+            key: formatName.field(fieldName),
             value: {
               description: field.description,
               type: gqlType,
               externalFieldName: fieldName,
-              resolve: (value: TValue): mixed => intoGqlOutput(field.getValue(value),
+              resolve: (value: TValue): mixed => intoGqlOutput(field.getValue(value)),
             },
           }
         },

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -48,7 +48,7 @@ export default function createCollectionGqlType<TValue> (
           const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, field.type)
           const formattedFieldName = formatName.field(fieldName)
           return {
-            key: formattedFieldName
+            key: formattedFieldName,
             value: {
               description: field.description,
               type: gqlType,

--- a/src/graphql/schema/collection/createCollectionGqlType.ts
+++ b/src/graphql/schema/collection/createCollectionGqlType.ts
@@ -53,9 +53,7 @@ export default function createCollectionGqlType<TValue> (
               description: field.description,
               type: gqlType,
               externalFieldName: fieldName,
-              resolve: (value) => {
-                return value.get(fieldName)
-              }
+              resolve: (value: TValue): mixed => intoGqlOutput(field.getValue(value),
             },
           }
         },

--- a/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
@@ -125,7 +125,7 @@ function createCollectionKeyField <TValue, TKey>(
     args: buildObject(inputHelpers.fieldEntries),
     async resolve (_source, args, context, resolveInfo): Promise<mixed> {
       const key = inputHelpers.getKeyFromInput(args)
-      const value = await collectionKey.read!(context, key, resolveInfo)
+      const value = await collectionKey.read!(context, key, resolveInfo, collectionGqlType)
       if (value == null) return
       return intoGqlOutput(value)
     },

--- a/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionQueryFieldEntries.ts
@@ -97,7 +97,7 @@ function createCollectionPrimaryKeyField <TValue, TKey>(
       const result = idSerde.deserialize(inventory, args[options.nodeIdFieldName] as string)
       if (result.collection !== collection) throw new Error(`The provided id is for collection '${result.collection.name}', not the expected collection '${collection.name}'.`)
       if (!keyType.isTypeOf(result.keyValue)) throw new Error(`The provided id is not of the correct type.`)
-      const value = await collectionKey.read!(context, result.keyValue, resolveInfo)
+      const value = await collectionKey.read!(context, result.keyValue, resolveInfo, collectionGqlType)
       if (value == null) return
       return intoGqlOutput(value)
     },

--- a/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
@@ -46,7 +46,7 @@ export default function createCollectionRelationTailGqlFieldEntries <TSource, TV
             : formatName.field(`${headCollection.type.name}-by-${relation.name}`),
           {
             description: `Reads a single ${scrib.type(headCollectionGqlType)} that is related to this ${scrib.type(collectionGqlType)}.`,
-            externalFieldNameDependencies: relation._tailFieldNames,
+            externalFieldNameDependencies: relation._tailFieldNames, // 🔥 Needs to account for classicIds
             type: headCollectionGqlType,
             async resolve (source: TSource, _args: {}, context: mixed, resolveInfo: mixed): Promise<mixed> {
               const value = options.getCollectionValue(source)

--- a/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
+++ b/src/graphql/schema/collection/createCollectionRelationTailGqlFieldEntries.ts
@@ -46,6 +46,7 @@ export default function createCollectionRelationTailGqlFieldEntries <TSource, TV
             : formatName.field(`${headCollection.type.name}-by-${relation.name}`),
           {
             description: `Reads a single ${scrib.type(headCollectionGqlType)} that is related to this ${scrib.type(collectionGqlType)}.`,
+            externalFieldNameDependencies: relation._tailFieldNames,
             type: headCollectionGqlType,
             async resolve (source: TSource, _args: {}, context: mixed, resolveInfo: mixed): Promise<mixed> {
               const value = options.getCollectionValue(source)

--- a/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
@@ -75,6 +75,6 @@ export default function createCreateCollectionMutationFieldEntry <TValue>(
     // transforming the correct input field.
     // TODO: test
     execute: (context, input, resolveInfo) =>
-      collection.create!(context, inputFromGqlInput(input[inputFieldName]), resolveInfo),
+      collection.create!(context, inputFromGqlInput(input[inputFieldName]), resolveInfo, collectionGqlType),
   })]
 }

--- a/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
@@ -74,7 +74,7 @@ export default function createCreateCollectionMutationFieldEntry <TValue>(
     // When we execute we just create a value in the collection after
     // transforming the correct input field.
     // TODO: test
-    execute: (context, input) =>
-      collection.create!(context, inputFromGqlInput(input[inputFieldName])),
+    execute: (context, input, resolveInfo) =>
+      collection.create!(context, inputFromGqlInput(input[inputFieldName]), resolveInfo),
   })]
 }

--- a/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createCreateCollectionMutationFieldEntry.ts
@@ -27,6 +27,7 @@ export default function createCreateCollectionMutationFieldEntry <TValue>(
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
+    relatedGqlType: collectionGqlType,
     description: `Creates a single ${scrib.type(collectionGqlType)}.`,
 
     inputFields: [

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
@@ -5,6 +5,7 @@ import BuildToken from '../../BuildToken'
 import createMutationGqlField from '../../createMutationGqlField'
 import createCollectionKeyInputHelpers from '../createCollectionKeyInputHelpers'
 import { getDeleteCollectionPayloadGqlType } from './createDeleteCollectionMutationFieldEntry'
+import getGqlOutputType from '../../type/getGqlOutputType'
 
 /**
  * Creates a delete mutation which will delete a single value from a collection
@@ -22,6 +23,7 @@ export default function createDeleteCollectionKeyMutationFieldEntry <TValue, TKe
   const { collection } = collectionKey
   const name = `delete-${collection.type.name}-by-${collectionKey.name}`
   const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)
+  const { gqlType } = getGqlOutputType(buildToken, collection.type)
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
@@ -29,6 +31,6 @@ export default function createDeleteCollectionKeyMutationFieldEntry <TValue, TKe
     inputFields: inputHelpers.fieldEntries,
     payloadType: getDeleteCollectionPayloadGqlType(buildToken, collection),
     execute: (context, input, resolveInfo) =>
-      collectionKey.delete!(context, inputHelpers.getKeyFromInput(input), resolveInfo),
+      collectionKey.delete!(context, inputHelpers.getKeyFromInput(input), resolveInfo, gqlType),
   })]
 }

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
@@ -28,7 +28,7 @@ export default function createDeleteCollectionKeyMutationFieldEntry <TValue, TKe
     description: `Deletes a single \`${formatName.type(collection.type.name)}\` using a unique key.`,
     inputFields: inputHelpers.fieldEntries,
     payloadType: getDeleteCollectionPayloadGqlType(buildToken, collection),
-    execute: (context, input) =>
-      collectionKey.delete!(context, inputHelpers.getKeyFromInput(input)),
+    execute: (context, input, resolveInfo) =>
+      collectionKey.delete!(context, inputHelpers.getKeyFromInput(input), resolveInfo),
   })]
 }

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionKeyMutationFieldEntry.ts
@@ -28,6 +28,7 @@ export default function createDeleteCollectionKeyMutationFieldEntry <TValue, TKe
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Deletes a single \`${formatName.type(collection.type.name)}\` using a unique key.`,
+    relatedGqlType: gqlType,
     inputFields: inputHelpers.fieldEntries,
     payloadType: getDeleteCollectionPayloadGqlType(buildToken, collection),
     execute: (context, input, resolveInfo) =>

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
@@ -40,13 +40,13 @@ export default function createDeleteCollectionMutationFieldEntry <TValue>(
     payloadType: getDeleteCollectionPayloadGqlType(buildToken, collection),
     // Execute by deserializing the id into its component parts and delete a
     // value in the collection using that key.
-    execute: (context, input) => {
+    execute: (context, input, resolveInfo) => {
       const result = idSerde.deserialize(inventory, input[options.nodeIdFieldName] as string)
 
       if (result.collection !== collection)
         throw new Error(`The provided id is for collection '${result.collection.name}', not the expected collection '${collection.name}'.`)
 
-      return primaryKey.delete!(context, result.keyValue)
+      return primaryKey.delete!(context, result.keyValue, resolveInfo)
     },
   })]
 }

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
@@ -27,9 +27,12 @@ export default function createDeleteCollectionMutationFieldEntry <TValue>(
   const { options, inventory } = buildToken
   const name = `delete-${collection.type.name}`
 
+  const { gqlType } = getGqlOutputType(buildToken, collection.type)
+
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Deletes a single \`${formatName.type(collection.type.name)}\` using its globally unique id.`,
+    relatedGqlType: gqlType,
     inputFields: [
       // The only input field we want is the globally unique id which
       // corresponds to the primary key of this collection.
@@ -67,6 +70,7 @@ function createDeleteCollectionPayloadGqlType <TValue>(
   const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, new NullableType(collection.type))
   return createMutationPayloadGqlType<TValue>(buildToken, {
     name: `delete-${collection.type.name}`,
+    relatedGqlType: gqlType,
     outputFields: [
       // Add the deleted value as an output field so the user can see the
       // object they just deleted.

--- a/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createDeleteCollectionMutationFieldEntry.ts
@@ -6,6 +6,7 @@ import createMutationGqlField from '../../createMutationGqlField'
 import createMutationPayloadGqlType from '../../createMutationPayloadGqlType'
 import getGqlOutputType from '../../type/getGqlOutputType'
 import createCollectionRelationTailGqlFieldEntries from '../createCollectionRelationTailGqlFieldEntries'
+import getGqlOutputType from '../../type/getGqlOutputType'
 
 /**
  * Creates a delete mutation that uses the primary key of a collection and an
@@ -43,10 +44,12 @@ export default function createDeleteCollectionMutationFieldEntry <TValue>(
     execute: (context, input, resolveInfo) => {
       const result = idSerde.deserialize(inventory, input[options.nodeIdFieldName] as string)
 
+      const { gqlType } = getGqlOutputType(buildToken, collection.type)
+
       if (result.collection !== collection)
         throw new Error(`The provided id is for collection '${result.collection.name}', not the expected collection '${collection.name}'.`)
 
-      return primaryKey.delete!(context, result.keyValue, resolveInfo)
+      return primaryKey.delete!(context, result.keyValue, resolveInfo, gqlType)
     },
   })]
 }

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
@@ -5,6 +5,7 @@ import BuildToken from '../../BuildToken'
 import createMutationGqlField from '../../createMutationGqlField'
 import createCollectionKeyInputHelpers from '../createCollectionKeyInputHelpers'
 import { getCollectionPatchType, getUpdateCollectionPayloadGqlType } from './createUpdateCollectionMutationFieldEntry'
+import getGqlOutputType from '../../type/getGqlOutputType'
 
 /**
  * Creates a update mutation which will update a single value from a collection
@@ -24,6 +25,7 @@ export default function createUpdateCollectionKeyMutationFieldEntry <TValue, TKe
   const inputHelpers = createCollectionKeyInputHelpers(buildToken, collectionKey)
   const patchFieldName = formatName.field(`${collection.type.name}-patch`)
   const { gqlType: patchGqlType, fromGqlInput: patchFromGqlInput } = getCollectionPatchType(buildToken, collection)
+  const { gqlType } = getGqlOutputType(buildToken, collection.type)
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
@@ -43,6 +45,6 @@ export default function createUpdateCollectionKeyMutationFieldEntry <TValue, TKe
     ],
     payloadType: getUpdateCollectionPayloadGqlType(buildToken, collection),
     execute: (context, input, resolveInfo) =>
-      collectionKey.update!(context, inputHelpers.getKeyFromInput(input), patchFromGqlInput(input[patchFieldName] as {}), resolveInfo),
+      collectionKey.update!(context, inputHelpers.getKeyFromInput(input), patchFromGqlInput(input[patchFieldName] as {}), resolveInfo, gqlType),
   })]
 }

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
@@ -30,6 +30,7 @@ export default function createUpdateCollectionKeyMutationFieldEntry <TValue, TKe
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Updates a single \`${formatName.type(collection.type.name)}\` using a unique key and a patch.`,
+    relatedGqlType: gqlType,
     inputFields: [
       // Include all of the fields we need to construct the key value we will
       // use to find the single value to update.

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionKeyMutationFieldEntry.ts
@@ -42,7 +42,7 @@ export default function createUpdateCollectionKeyMutationFieldEntry <TValue, TKe
       }],
     ],
     payloadType: getUpdateCollectionPayloadGqlType(buildToken, collection),
-    execute: (context, input) =>
-      collectionKey.update!(context, inputHelpers.getKeyFromInput(input), patchFromGqlInput(input[patchFieldName] as {})),
+    execute: (context, input, resolveInfo) =>
+      collectionKey.update!(context, inputHelpers.getKeyFromInput(input), patchFromGqlInput(input[patchFieldName] as {}), resolveInfo),
   })]
 }

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
@@ -61,10 +61,12 @@ export default function createUpdateCollectionMutationFieldEntry <TValue>(
     execute: (context, input, resolveInfo) => {
       const result = idSerde.deserialize(inventory, input[options.nodeIdFieldName] as string)
 
+      const { gqlType } = getGqlOutputType(buildToken, collection.type)
+
       if (result.collection !== collection)
         throw new Error(`The provided id is for collection '${result.collection.name}', not the expected collection '${collection.name}'.`)
 
-      return primaryKey.update!(context, result.keyValue, patchFromGqlInput(input[patchFieldName] as {}), resolveInfo)
+      return primaryKey.update!(context, result.keyValue, patchFromGqlInput(input[patchFieldName] as {}), resolveInfo, gqlType)
     },
   })]
 }

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
@@ -58,13 +58,13 @@ export default function createUpdateCollectionMutationFieldEntry <TValue>(
     payloadType: getUpdateCollectionPayloadGqlType(buildToken, collection),
     // Execute by deserializing the id into its component parts and update a
     // value in the collection using that key.
-    execute: (context, input) => {
+    execute: (context, input, resolveInfo) => {
       const result = idSerde.deserialize(inventory, input[options.nodeIdFieldName] as string)
 
       if (result.collection !== collection)
         throw new Error(`The provided id is for collection '${result.collection.name}', not the expected collection '${collection.name}'.`)
 
-      return primaryKey.update!(context, result.keyValue, patchFromGqlInput(input[patchFieldName] as {}))
+      return primaryKey.update!(context, result.keyValue, patchFromGqlInput(input[patchFieldName] as {}), resolveInfo)
     },
   })]
 }

--- a/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
+++ b/src/graphql/schema/collection/mutations/createUpdateCollectionMutationFieldEntry.ts
@@ -35,10 +35,12 @@ export default function createUpdateCollectionMutationFieldEntry <TValue>(
   const name = `update-${collection.type.name}`
   const patchFieldName = formatName.field(`${collection.type.name}-patch`)
   const { gqlType: patchGqlType, fromGqlInput: patchFromGqlInput } = getCollectionPatchType(buildToken, collection)
+  const { gqlType } = getGqlOutputType(buildToken, collection.type)
 
   return [formatName.field(name), createMutationGqlField<TValue>(buildToken, {
     name,
     description: `Updates a single \`${formatName.type(collection.type.name)}\` using its globally unique id and a patch.`,
+    relatedGqlType: gqlType,
     inputFields: [
       // The only input field we want is the globally unique id which
       // corresponds to the primary key of this collection.
@@ -139,6 +141,7 @@ function createUpdateCollectionPayloadGqlType <TValue>(
   const { gqlType, intoGqlOutput } = getGqlOutputType(buildToken, new NullableType(collection.type))
   return createMutationPayloadGqlType<TValue>(buildToken, {
     name: `update-${collection.type.name}`,
+    relatedGqlType: gqlType,
     outputFields: [
       // Add the updated value as an output field so the user can see the
       // object they just updated.

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -26,7 +26,7 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
     inputArgEntries?: Array<[string, GraphQLArgumentConfig]>,
     getPaginatorInput: (source: TSource, args: { [key: string]: mixed }) => TInput,
     subquery?: boolean = false,
-    relation: Relation,
+    relation?: Relation = null,
   },
 ): GraphQLFieldConfig<TSource, Connection<TInput, TItemValue, mixed>> {
   const { gqlType } = getGqlOutputType(buildToken, paginator.itemType)
@@ -123,7 +123,7 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
     const sourceName = (_, fieldName, args, alias) => `${fieldName}###${alias || ''}`
     Object.assign(result, {
       sourceName,
-      externalFieldNameDependencies: config.relation._headFieldNames,
+      externalFieldNameDependencies: config.relation && config.relation._headFieldNames,
       sqlExpression: (aliasIdentifier, fieldName, args, resolveInfo) => {
         const {ordering, orderingName, input, pageConfig} = getOrdering(aliasIdentifier, args)
         const alias = Symbol();

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -126,7 +126,7 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
         const {ordering, orderingName, input, pageConfig} = getOrdering(aliasIdentifier, args)
         const alias = Symbol();
         const {query} = ordering.generateQuery(input, pageConfig, resolveInfo, gqlType)
-        return sql.query`(select json_build_object('rows', rows, 'hasNextPage', "hasNextPage", 'hasPreviousPage', "hasPreviousPage") from (${query}) as ${sql.identifier(alias)})`
+        return sql.query`(select json_build_object('rows', rows, 'hasNextPage', "hasNextPage", 'hasPreviousPage', "hasPreviousPage", 'totalCount', "totalCount") from (${query}) as ${sql.identifier(alias)})`
       },
       async resolve (source, args, context, resolveInfo): Promise<mixed> {
         // 🔥 Need to apply this to the other places that user alias too!
@@ -198,8 +198,7 @@ export function _createConnectionGqlType <TInput, TItemValue>(
       totalCount: {
         description: `The count of *all* ${scrib.type(gqlType)} you could get from the connection.`,
         type: GraphQLInt,
-        resolve: ({ input }, _args, context) =>
-          paginator.count(context, input),
+        resolve: async source => source.page.totalCount(),
       },
       edges: {
         description: `A list of edges which contains the ${scrib.type(gqlType)} and cursor to aid in pagination.`,

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -129,7 +129,10 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
         return sql.query`(select json_build_object('rows', rows, 'hasNextPage', "hasNextPage", 'hasPreviousPage', "hasPreviousPage") from (${query}) as ${sql.identifier(alias)})`
       },
       async resolve (source, args, context, resolveInfo): Promise<mixed> {
-        const value = source.get(sqlName(null, resolveInfo.fieldName, args, resolveInfo.alias && resolveInfo.alias.value))
+        // 🔥 Need to apply this to the other places that user alias too!
+        const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
+        const alias = fieldNodes[0].alias && fieldNodes[0].alias.value
+        const value = source.get(sqlName(null, resolveInfo.fieldName, args, alias))
         // XXX: tweak value to be in same format as before, don't forget to re-order the rows if necessary!
         const {ordering, orderingName, input, pageConfig} = getOrdering(
           Symbol(), // <-- this doesn't matter during resolve

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -129,7 +129,6 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
         return sql.query`(select json_build_object('rows', rows, 'hasNextPage', "hasNextPage", 'hasPreviousPage', "hasPreviousPage", 'totalCount', "totalCount") from (${query}) as ${sql.identifier(alias)})`
       },
       async resolve (source, args, context, resolveInfo): Promise<mixed> {
-        // 🔥 Need to apply this to the other places that user alias too!
         const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
         const alias = fieldNodes[0].alias && fieldNodes[0].alias.value
         const value = source.get(sourceName(null, resolveInfo.fieldName, args, alias))

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -123,7 +123,7 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
     const sourceName = (_, fieldName, args, alias) => `${fieldName}###${alias || ''}`
     Object.assign(result, {
       sourceName,
-      externalFieldNameDependencies: config.relation && config.relation._headFieldNames,
+      externalFieldNameDependencies: config.relation && config.relation._headFieldNames, // 🔥 Needs to account for classicIds
       sqlExpression: (aliasIdentifier, fieldName, args, resolveInfo) => {
         const {ordering, orderingName, input, pageConfig} = getOrdering(aliasIdentifier, args)
         const alias = Symbol();

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -187,6 +187,7 @@ export function _createConnectionGqlType <TInput, TItemValue>(
   return new GraphQLObjectType({
     name: formatName.type(`${paginator.name}-connection`),
     description: `A connection to a list of ${scrib.type(gqlType)} values.`,
+    // When performing optimisations, this is useful when parsing the resolveInfo AST tree:
     relatedGqlType: gqlType,
     fields: () => ({
       pageInfo: {
@@ -230,6 +231,7 @@ export function _createEdgeGqlType <TInput, TItemValue>(
   return new GraphQLObjectType({
     name: formatName.type(`${paginator.name}-edge`),
     description: `A ${scrib.type(gqlType)} edge in the connection.`,
+    // When performing optimisations, this is useful when parsing the resolveInfo AST tree:
     relatedGqlType: gqlType,
     fields: () => ({
       cursor: {

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -119,9 +119,9 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
       }
     }
   if (subquery) {
-    const sqlName = (_, fieldName, args, alias) => `${fieldName}###${alias || ''}`
+    const sourceName = (_, fieldName, args, alias) => `${fieldName}###${alias || ''}`
     Object.assign(result, {
-      sqlName,
+      sourceName,
       sqlExpression: (aliasIdentifier, fieldName, args, resolveInfo) => {
         const {ordering, orderingName, input, pageConfig} = getOrdering(aliasIdentifier, args)
         const alias = Symbol();
@@ -132,7 +132,7 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
         // 🔥 Need to apply this to the other places that user alias too!
         const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
         const alias = fieldNodes[0].alias && fieldNodes[0].alias.value
-        const value = source.get(sqlName(null, resolveInfo.fieldName, args, alias))
+        const value = source.get(sourceName(null, resolveInfo.fieldName, args, alias))
         // XXX: tweak value to be in same format as before, don't forget to re-order the rows if necessary!
         const {ordering, orderingName, input, pageConfig} = getOrdering(
           Symbol(), // <-- this doesn't matter during resolve

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -197,7 +197,7 @@ export function _createConnectionGqlType <TInput, TItemValue>(
       totalCount: {
         description: `The count of *all* ${scrib.type(gqlType)} you could get from the connection.`,
         type: GraphQLInt,
-        resolve: async source => source.page.totalCount(),
+        resolve: source => source.page.totalCount(),
       },
       edges: {
         description: `A list of edges which contains the ${scrib.type(gqlType)} and cursor to aid in pagination.`,

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -25,8 +25,9 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
     description?: string,
     inputArgEntries?: Array<[string, GraphQLArgumentConfig]>,
     getPaginatorInput: (source: TSource, args: { [key: string]: mixed }) => TInput,
+    subquery?: boolean = false,
+    relation: Relation,
   },
-  subquery?: boolean = false,
 ): GraphQLFieldConfig<TSource, Connection<TInput, TItemValue, mixed>> {
   const { gqlType } = getGqlOutputType(buildToken, paginator.itemType)
 
@@ -118,10 +119,11 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
         pageConfig,
       }
     }
-  if (subquery) {
+  if (config.subquery) {
     const sourceName = (_, fieldName, args, alias) => `${fieldName}###${alias || ''}`
     Object.assign(result, {
       sourceName,
+      externalFieldNameDependencies: config.relation._headFieldNames,
       sqlExpression: (aliasIdentifier, fieldName, args, resolveInfo) => {
         const {ordering, orderingName, input, pageConfig} = getOrdering(aliasIdentifier, args)
         const alias = Symbol();

--- a/src/graphql/schema/connection/createConnectionGqlField.ts
+++ b/src/graphql/schema/connection/createConnectionGqlField.ts
@@ -126,12 +126,12 @@ export default function createConnectionGqlField <TSource, TInput, TItemValue>(
         const {ordering, orderingName, input, pageConfig} = getOrdering(aliasIdentifier, args)
         const alias = Symbol();
         const {query} = ordering.generateQuery(input, pageConfig, resolveInfo, gqlType)
-        return sql.query`to_json((${)query})`
+        return sql.query`(select json_build_object('rows', rows, 'hasNextPage', "hasNextPage", 'hasPreviousPage', "hasPreviousPage") from (${query}) as ${sql.identifier(alias)})`
       },
       async resolve (source, args, context, resolveInfo): Promise<mixed> {
-        const value = source.get(sqlName(null, null, args, resolveInfo.alias && resolveInfo.alias.value))
+        const value = source.get(sqlName(null, resolveInfo.fieldName, args, resolveInfo.alias && resolveInfo.alias.value))
         // XXX: tweak value to be in same format as before, don't forget to re-order the rows if necessary!
-        const {ordering, orderingName, input} = getOrdering(
+        const {ordering, orderingName, input, pageConfig} = getOrdering(
           Symbol(), // <-- this doesn't matter during resolve
           args
         )

--- a/src/graphql/schema/createMutationGqlField.ts
+++ b/src/graphql/schema/createMutationGqlField.ts
@@ -21,7 +21,7 @@ type MutationFieldConfig<T> = {
   inputFields?: Array<[string, GraphQLInputFieldConfig] | false | null | undefined>,
   outputFields?: Array<[string, GraphQLFieldConfig<T, mixed>] | false | null | undefined>,
   payloadType?: GraphQLObjectType,
-  execute: (context: mixed, input: { [name: string]: mixed }) => Promise<T>,
+  execute: (context: mixed, input: { [name: string]: mixed }, resolveInfo) => Promise<T>,
 }
 
 /**
@@ -91,9 +91,9 @@ export default function createMutationGqlField <T>(
     // Finally we define the resolver for this field which will actually
     // execute the mutation. Basically it will just include the
     // `clientMutationId` in the payload, and calls `config.execute`.
-    async resolve (_source, args, context): Promise<MutationValue<T>> {
+    async resolve (_source, args, context, resolveInfo): Promise<MutationValue<T>> {
       const { clientMutationId } = args['input']
-      const value = await config.execute(context, args['input'])
+      const value = await config.execute(context, args['input'], resolveInfo)
 
       return {
         clientMutationId,

--- a/src/graphql/schema/createMutationPayloadGqlType.ts
+++ b/src/graphql/schema/createMutationPayloadGqlType.ts
@@ -18,6 +18,7 @@ export default function createMutationPayloadGqlType <TValue>(
   return new GraphQLObjectType({
     name: formatName.type(`${config.name}-payload`),
     description: `The output of our \`${formatName.field(config.name)}\` mutation.`,
+    relatedGqlType: config.relatedGqlType,
     fields: buildObject<GraphQLFieldConfig<MutationValue<TValue>, mixed>>(
       [
         // Add the `clientMutationId` output field. This will be the exact

--- a/src/graphql/schema/type/getGqlOutputType.ts
+++ b/src/graphql/schema/type/getGqlOutputType.ts
@@ -161,7 +161,7 @@ const createGqlOutputType = <TValue>(buildToken: BuildToken, _type: Type<TValue>
                   value: {
                     description: field.description,
                     type: gqlType,
-                    externalFieldName: fieldName,
+                    externalFieldName: field.externalFieldName,
                     resolve: (value: TValue): mixed => intoGqlOutput(field.getValue(value)),
                   },
                 }

--- a/src/graphql/schema/type/getGqlOutputType.ts
+++ b/src/graphql/schema/type/getGqlOutputType.ts
@@ -161,6 +161,7 @@ const createGqlOutputType = <TValue>(buildToken: BuildToken, _type: Type<TValue>
                   value: {
                     description: field.description,
                     type: gqlType,
+                    externalFieldName: fieldName,
                     resolve: (value: TValue): mixed => intoGqlOutput(field.getValue(value)),
                   },
                 }

--- a/src/interface/Paginator.ts
+++ b/src/interface/Paginator.ts
@@ -100,6 +100,11 @@ namespace Paginator {
       resolveInfo: mixed,
       gqlType: mixed,
     ): mixed
+
+    valueToPage (
+      value: mixed,
+      details: mixed,
+    ): mixed
   }
 
   /**

--- a/src/interface/Paginator.ts
+++ b/src/interface/Paginator.ts
@@ -93,6 +93,13 @@ namespace Paginator {
       resolveInfo: mixed,
       gqlType: mixed,
     ): Promise<Paginator.Page<TItemValue, TCursor>>
+
+    generateQuery (
+      input: TInput,
+      config: Paginator.PageConfig<TCursor>,
+      resolveInfo: mixed,
+      gqlType: mixed,
+    ): mixed
   }
 
   /**

--- a/src/interface/collection/Condition.ts
+++ b/src/interface/collection/Condition.ts
@@ -68,6 +68,10 @@ export namespace conditionHelpers {
   export function fieldEquals (name: string, value: mixed): Condition {
     return { type: 'FIELD', name, condition: { type: 'EQUAL', value } }
   }
+
+  export function fieldEqualsQuery (name: string, value: mixed): Condition {
+    return { type: 'FIELD', name, condition: { type: 'EQUAL_QUERY', value } }
+  }
 }
 
 /**

--- a/src/interface/collection/Relation.ts
+++ b/src/interface/collection/Relation.ts
@@ -58,6 +58,7 @@ interface Relation<TTailValue, THeadValue, THeadKey> {
    */
   // TODO: REFACTOR
   getTailConditionFromHeadValue? (value: THeadValue): Condition
+  getTailConditionFromHeadAlias? (aliasIdentifier: mixed): Condition
 }
 
 export default Relation

--- a/src/postgraphql/graphiql/src/components/PostGraphiQL.js
+++ b/src/postgraphql/graphiql/src/components/PostGraphiQL.js
@@ -62,7 +62,7 @@ class PostGraphiQL extends React.Component {
         'Authorization': `Bearer ${jwtToken}`,
       } : {}),
       body: JSON.stringify(graphQLParams),
-      credentials: 'include',
+      credentials: 'same-origin',
     })
 
     const result = await response.json()

--- a/src/postgraphql/graphiql/src/components/PostGraphiQL.js
+++ b/src/postgraphql/graphiql/src/components/PostGraphiQL.js
@@ -62,6 +62,7 @@ class PostGraphiQL extends React.Component {
         'Authorization': `Bearer ${jwtToken}`,
       } : {}),
       body: JSON.stringify(graphQLParams),
+      credentials: 'include',
     })
 
     const result = await response.json()

--- a/src/postgraphql/schema/procedures/PgProcedurePaginator.ts
+++ b/src/postgraphql/schema/procedures/PgProcedurePaginator.ts
@@ -50,8 +50,8 @@ class PgProcedurePaginator<TItemValue> extends PgPaginator<ProcedureInput, TItem
    * The from entry for this paginator is a Postgres function call where the
    * procedure is the function being called.
    */
-  public getFromEntrySql (input: ProcedureInput): sql.Sql {
-    return createPgProcedureSqlCall(this._fixtures, input)
+  public getFromEntrySql (input: ProcedureInput, firstArgumentIsTableName = false): sql.Sql {
+    return createPgProcedureSqlCall(this._fixtures, input, firstArgumentIsTableName)
   }
 
   /**

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -18,7 +18,7 @@ import pgClientFromContext from '../../../postgres/inventory/pgClientFromContext
 import createPgProcedureFixtures from './createPgProcedureFixtures'
 import createPgProcedureSqlCall from './createPgProcedureSqlCall'
 import { getEdgeGqlType, createOrderByGqlArg } from '../../../graphql/schema/connection/createConnectionGqlField'
-import getSelectFragment, {getFieldsFromResolveInfo, getSelectFragmentFromFields} from '../../../postgres/inventory/paginator/getSelectFragment'
+import getSelectFragment from '../../../postgres/inventory/paginator/getSelectFragment'
 
 /**
  * Creates a single mutation GraphQL field entry for our procedure. We use the

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -18,6 +18,7 @@ import pgClientFromContext from '../../../postgres/inventory/pgClientFromContext
 import createPgProcedureFixtures from './createPgProcedureFixtures'
 import createPgProcedureSqlCall from './createPgProcedureSqlCall'
 import { getEdgeGqlType, createOrderByGqlArg } from '../../../graphql/schema/connection/createConnectionGqlField'
+import {getFieldsFromResolveInfo, getSelectFragmentFromFields} from '../paginator/getSelectFragment'
 
 /**
  * Creates a single mutation GraphQL field entry for our procedure. We use the
@@ -95,7 +96,7 @@ export default function createPgProcedureMutationGqlFieldEntry (
     ],
 
     // Actually execute the procedure here.
-    async execute (context, gqlInput): Promise<mixed> {
+    async execute (context, gqlInput, resolveInfo): Promise<mixed> {
       const client = pgClientFromContext(context)
 
       // Turn our GraphQL input into an input tuple.
@@ -108,8 +109,8 @@ export default function createPgProcedureMutationGqlFieldEntry (
       const aliasIdentifier = Symbol()
 
       const query = sql.compile(
-        return sql.query`
-          select to_json(${sql.identifier(aliasIdentifier)}) as value
+        sql.query`
+          select ${getSelectFragment(resolveInfo, aliasIdentifier, fixtures.return.gqlType)} as value
           from ${procedureCall} as ${sql.identifier(aliasIdentifier)}
         `
       )

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -108,10 +108,10 @@ export default function createPgProcedureMutationGqlFieldEntry (
       const aliasIdentifier = Symbol()
 
       const query = sql.compile(
-        // If the procedure returns a set, we must select a set of values.
-        pgProcedure.returnsSet
-          ? sql.query`select to_json(${sql.identifier(aliasIdentifier)}) as value from ${procedureCall} as ${sql.identifier(aliasIdentifier)}`
-          : sql.query`select to_json(${procedureCall}) as value`,
+        return sql.query`
+          select to_json(${sql.identifier(aliasIdentifier)}) as value
+          from ${procedureCall} as ${sql.identifier(aliasIdentifier)}
+        `
       )
 
       const { rows } = await client.query(query)

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -53,6 +53,7 @@ export default function createPgProcedureMutationGqlFieldEntry (
   return [formatName.field(pgProcedure.name), createMutationGqlField<mixed>(buildToken, {
     name: pgProcedure.name,
     description: pgProcedure.description,
+    relatedGqlType: fixtures.return.gqlType,
 
     inputFields,
 

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -18,7 +18,7 @@ import pgClientFromContext from '../../../postgres/inventory/pgClientFromContext
 import createPgProcedureFixtures from './createPgProcedureFixtures'
 import createPgProcedureSqlCall from './createPgProcedureSqlCall'
 import { getEdgeGqlType, createOrderByGqlArg } from '../../../graphql/schema/connection/createConnectionGqlField'
-import {getFieldsFromResolveInfo, getSelectFragmentFromFields} from '../paginator/getSelectFragment'
+import getSelectFragment, {getFieldsFromResolveInfo, getSelectFragmentFromFields} from '../../../postgres/inventory/paginator/getSelectFragment'
 
 /**
  * Creates a single mutation GraphQL field entry for our procedure. We use the

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -96,5 +96,5 @@ function createPgSetProcedureQueryGqlFieldEntry (
     inputArgEntries,
     getPaginatorInput: (source, args) =>
       [source, ...inputArgEntries.map(([argName], i) => fixtures.args[i + 1].fromGqlInput(args[argName]))],
-  })]
+  }, true)]
 }

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -50,19 +50,19 @@ function createPgSingleProcedureQueryGqlFieldEntry (
   )
 
   const fieldName = formatName.field(pgProcedure.name.substring(fixtures.args[0].pgType.name.length + 1))
-  const sqlName = (_tbl, _fld, args, alias) => `${fieldName}###${alias || ''}`,
+  const sourceName = (_tbl, _fld, args, alias) => `${fieldName}###${alias || ''}`,
   return [fieldName, {
     description: pgProcedure.description,
     type: fixtures.return.gqlType,
     args: buildObject(argEntries),
-    sqlName,
+    sourceName,
     sqlExpression: (aliasIdentifier, gqlFieldName, args, context) => {
       const input = argEntries.map(([argName], i) => fixtures.args[i + 2].fromGqlInput(args[argName]))
       return createPgProcedureSqlCall(fixtures, aliasIdentifier, input)
     },
 
     async resolve (source, args, context, resolveInfo): Promise<mixed> {
-      const value = source.get(sqlName(null, null, args, resolveInfo.alias && resolveInfo.alias.value))
+      const value = source.get(sourceName(null, null, args, resolveInfo.alias && resolveInfo.alias.value))
       return fixtures.return.intoGqlOutput(value)
     },
   }]

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -58,14 +58,14 @@ function createPgSingleProcedureQueryGqlFieldEntry (
     sourceName,
     sqlExpression: (aliasIdentifier, gqlFieldName, args, context) => {
       const input = [aliasIdentifier].concat(argEntries.map(([argName], i) => fixtures.args[i + 1].fromGqlInput(args[argName])))
-      return createPgProcedureSqlCall(fixtures, input, true)
+      return `(${createPgProcedureSqlCall(fixtures, input, true)})`
     },
 
     async resolve (source, args, context, resolveInfo): Promise<mixed> {
       const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
       const alias = fieldNodes[0].alias && fieldNodes[0].alias.value
       const value = source.get(sourceName(null, null, args, alias))
-      return fixtures.return.intoGqlOutput(value)
+      return value != null ? fixtures.return.intoGqlOutput(value) : null
     },
   }]
 }

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -57,8 +57,8 @@ function createPgSingleProcedureQueryGqlFieldEntry (
     args: buildObject(argEntries),
     sourceName,
     sqlExpression: (aliasIdentifier, gqlFieldName, args, context) => {
-      const input = argEntries.map(([argName], i) => fixtures.args[i + 2].fromGqlInput(args[argName]))
-      return createPgProcedureSqlCall(fixtures, aliasIdentifier, input)
+      const input = [aliasIdentifier].concat(argEntries.map(([argName], i) => fixtures.args[i + 1].fromGqlInput(args[argName])))
+      return createPgProcedureSqlCall(fixtures, input, true)
     },
 
     async resolve (source, args, context, resolveInfo): Promise<mixed> {

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -50,19 +50,19 @@ function createPgSingleProcedureQueryGqlFieldEntry (
   )
 
   const fieldName = formatName.field(pgProcedure.name.substring(fixtures.args[0].pgType.name.length + 1))
-  const sqlName = (_, args, alias) => `${fieldName}###${alias || ''}`,
+  const sqlName = (_tbl, _fld, args, alias) => `${fieldName}###${alias || ''}`,
   return [fieldName, {
     description: pgProcedure.description,
     type: fixtures.return.gqlType,
     args: buildObject(argEntries),
     sqlName,
-    sqlExpression: (aliasIdentifier, args, context) => {
+    sqlExpression: (aliasIdentifier, gqlFieldName, args, context) => {
       const input = argEntries.map(([argName], i) => fixtures.args[i + 2].fromGqlInput(args[argName]))
       return createPgProcedureSqlCall(fixtures, aliasIdentifier, input)
     },
 
     async resolve (source, args, context, resolveInfo): Promise<mixed> {
-      const value = source.get(sqlName(null, args, resolveInfo.alias && resolveInfo.alias.value))
+      const value = source.get(sqlName(null, null, args, resolveInfo.alias && resolveInfo.alias.value))
       return fixtures.return.intoGqlOutput(value)
     },
   }]

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -67,14 +67,14 @@ function createPgSingleProcedureQueryGqlFieldEntry (
       const attrName = sourceName(null, null, args, alias)
       if (source.has(attrName)) {
         const value = source.get(attrName)
-        return value != null ? fixtures.return.intoGqlOutput(value) : null
+        return value != null ? fixtures.return.intoGqlOutput(fixtures.return.type.transformPgValueIntoValue(value)) : null
       } else {
         // Subquery failed (e.g. computed function as subfield of compound type); fall back to old logic
         const client = pgClientFromContext(context)
         const input = [source, ...argEntries.map(([argName], i) => fixtures.args[i + 1].fromGqlInput(args[argName]))]
         const query = sql.compile(sql.query`select to_json(${createPgProcedureSqlCall(fixtures, input)}) as value`)
         const { rows: [row] } = await client.query(query)
-        return row ? fixtures.return.intoGqlOutput(row['value']) : null
+        return row ? fixtures.return.intoGqlOutput(fixtures.return.type.transformPgValueIntoValue(row['value'])) : null
       }
     },
   }]

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -58,7 +58,7 @@ function createPgSingleProcedureQueryGqlFieldEntry (
     sourceName,
     sqlExpression: (aliasIdentifier, gqlFieldName, args, context) => {
       const input = [aliasIdentifier].concat(argEntries.map(([argName], i) => fixtures.args[i + 1].fromGqlInput(args[argName])))
-      return `(${createPgProcedureSqlCall(fixtures, input, true)})`
+      return sql.query`(${createPgProcedureSqlCall(fixtures, input, true)})`
     },
 
     async resolve (source, args, context, resolveInfo): Promise<mixed> {

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -62,7 +62,9 @@ function createPgSingleProcedureQueryGqlFieldEntry (
     },
 
     async resolve (source, args, context, resolveInfo): Promise<mixed> {
-      const value = source.get(sourceName(null, null, args, resolveInfo.alias && resolveInfo.alias.value))
+      const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
+      const alias = fieldNodes[0].alias && fieldNodes[0].alias.value
+      const value = source.get(sourceName(null, null, args, alias))
       return fixtures.return.intoGqlOutput(value)
     },
   }]

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -98,5 +98,6 @@ function createPgSetProcedureQueryGqlFieldEntry (
     inputArgEntries,
     getPaginatorInput: (source, args) =>
       [source, ...inputArgEntries.map(([argName], i) => fixtures.args[i + 1].fromGqlInput(args[argName]))],
-  }, true)]
+    subquery: true,
+  })]
 }

--- a/src/postgraphql/schema/procedures/createPgProcedureQueryGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureQueryGqlFieldEntry.ts
@@ -57,11 +57,12 @@ function createPgSingleProcedureQueryGqlFieldEntry (
       const input = argEntries.map(([argName], i) => fixtures.args[i].fromGqlInput(args[argName]))
       const aliasIdentifier = Symbol()
       const query = sql.compile(sql.query`
-        select ${getSelectFragment(resolveInfo, aliasIdentifier, fixtures.return.gqlType)} as value
+        select ${getSelectFragment(resolveInfo, aliasIdentifier, fixtures.return.gqlType)} as value,
+        (${sql.identifier(aliasIdentifier)} is null) as is_null
         from ${createPgProcedureSqlCall(fixtures, input)} as ${sql.identifier(aliasIdentifier)}
       `)
       const { rows: [row] } = await client.query(query)
-      return row ? fixtures.return.intoGqlOutput(fixtures.return.type.transformPgValueIntoValue(row['value'])) : null
+      return row && !row['is_null'] ? fixtures.return.intoGqlOutput(fixtures.return.type.transformPgValueIntoValue(row['value'])) : null
     },
   }]
 }

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -175,7 +175,7 @@ const debugPgExplain = createDebugger('postgraphql:postgres:explain')
  * @private
  */
 // tslint:disable no-any
-function debugPgClient (pgClient: Client): Client {
+export function debugPgClient (pgClient: Client): Client {
   // If Postgres debugging is enabled, enhance our query function by adding
   // a debug statement.
   if (debugPg.enabled || debugPgExplain.enabled) {

--- a/src/postgres/inventory/collection/PgCollection.ts
+++ b/src/postgres/inventory/collection/PgCollection.ts
@@ -166,7 +166,7 @@ class PgCollection implements Collection<PgClassType.Value> {
             returning *
           )
           -- We use a subquery with our insert so we can turn the result into JSON.
-          select ${getSelectFragmentFromFields(fields)} as object
+          select ${getSelectFragmentFromFields(fields, insertionIdentifier)} as object
           from ${sql.identifier(insertionIdentifier)}
         `)
 

--- a/src/postgres/inventory/collection/PgCollectionKey.ts
+++ b/src/postgres/inventory/collection/PgCollectionKey.ts
@@ -222,10 +222,10 @@ class PgCollectionKey implements CollectionKey<PgClassType.Value, PgCollectionKe
    * This method, unlike many of the other asynchronous actions in Postgres
    * collections, is not batched.
    */
-  public update: ((context: mixed, key: PgClassType.Value, patch: Map<string, mixed>) => Promise<PgClassType.Value | null>) | null = (
+  public update: ((context: mixed, key: PgClassType.Value, patch: Map<string, mixed>, resolveInfo) => Promise<PgClassType.Value | null>) | null = (
     !this._pgClass.isUpdatable
       ? null
-      : async (context: mixed, key: PgClassType.Value, patch: Map<string, mixed>): Promise<PgClassType.Value> => {
+      : async (context: mixed, key: PgClassType.Value, patch: Map<string, mixed>, resolveInfo): Promise<PgClassType.Value> => {
         const client = pgClientFromContext(context)
 
         const updatedIdentifier = Symbol()
@@ -270,10 +270,10 @@ class PgCollectionKey implements CollectionKey<PgClassType.Value, PgCollectionKe
    *
    * This method, unlike many others in Postgres collections, is not batched.
    */
-  public delete: ((context: mixed, key: PgClassType.Value) => Promise<PgClassType.Value | null>) | null = (
+  public delete: ((context: mixed, key: PgClassType.Value, resolveInfo) => Promise<PgClassType.Value | null>) | null = (
     !this._pgClass.isDeletable
       ? null
-      : async (context: mixed, key: PgClassType.Value): Promise<PgClassType.Value> => {
+      : async (context: mixed, key: PgClassType.Value, resolveInfo): Promise<PgClassType.Value> => {
         const client = pgClientFromContext(context)
 
         const deletedIdentifier = Symbol()

--- a/src/postgres/inventory/collection/PgCollectionKey.ts
+++ b/src/postgres/inventory/collection/PgCollectionKey.ts
@@ -135,7 +135,7 @@ class PgCollectionKey implements CollectionKey<PgClassType.Value, PgCollectionKe
    * @private
    */
   @memoizeMethod
-  private _getSelectLoader (client: Client, resolveInfo: mixed, collectionGqlType: mixed): DataLoader<PgClassType.Value, PgClassType.Value | null> {
+  private _getSelectLoader (client: Client): DataLoader<PgClassType.Value, PgClassType.Value | null> {
     return new DataLoader<PgClassType.Value, PgClassType.Value | null>(
       async (keysAndStuff: mixed): Promise<Array<PgClassType.Value | null>> => {
         const aliasIdentifier = Symbol()

--- a/src/postgres/inventory/collection/PgCollectionKey.ts
+++ b/src/postgres/inventory/collection/PgCollectionKey.ts
@@ -207,6 +207,11 @@ class PgCollectionKey implements CollectionKey<PgClassType.Value, PgCollectionKe
           return values.get(keyString) || null
         })
       },
+      {
+        // If we come back later but requesting more fields, we may need to refetch so disable per-key results caching
+        cache: false,
+        // XXX: implement cacheKeyFn
+      },
     )
   }
 

--- a/src/postgres/inventory/collection/PgCollectionKey.ts
+++ b/src/postgres/inventory/collection/PgCollectionKey.ts
@@ -166,7 +166,7 @@ class PgCollectionKey implements CollectionKey<PgClassType.Value, PgCollectionKe
         // compiling.
         const query = sql.compile(sql.query`
           -- Select our rows as JSON objects.
-          select ${getSelectFragmentFromFields(fields)} as object
+          select ${getSelectFragmentFromFields(fields, aliasIdentifier)} as object
           from ${sql.identifier(this._pgNamespace.name, this._pgClass.name)} as ${sql.identifier(aliasIdentifier)}
 
           -- For all of our key attributes we need to test equality with a

--- a/src/postgres/inventory/collection/PgCollectionKey.ts
+++ b/src/postgres/inventory/collection/PgCollectionKey.ts
@@ -202,7 +202,7 @@ class PgCollectionKey implements CollectionKey<PgClassType.Value, PgCollectionKe
           return [keyString, value]
         }))
 
-        return keys.map(key => {
+        return keysAndStuff.map(({key}) => {
           const keyString = this._keyTypeFields.map(([fieldName]) => key.get(fieldName)).join('-')
           return values.get(keyString) || null
         })

--- a/src/postgres/inventory/collection/PgCollectionKey.ts
+++ b/src/postgres/inventory/collection/PgCollectionKey.ts
@@ -45,6 +45,7 @@ class PgCollectionKey implements CollectionKey<PgClassType.Value, PgCollectionKe
       return [fieldName, {
         description: pgAttribute.description,
         type,
+        externalFieldName: pgAttribute.name,
         pgAttribute,
         getValue: value => value.get(fieldName),
       }]

--- a/src/postgres/inventory/collection/PgRelation.ts
+++ b/src/postgres/inventory/collection/PgRelation.ts
@@ -3,6 +3,7 @@ import { PgCatalog, PgCatalogAttribute, PgCatalogForeignKeyConstraint } from '..
 import PgClassType from '../type/PgClassType'
 import PgCollection from './PgCollection'
 import PgCollectionKey from './PgCollectionKey'
+import { sql } from '../../utils'
 
 // TODO: This implementation is sketchy. Implement it better!
 // TODO: Tests
@@ -42,6 +43,12 @@ class PgRelation implements Relation<PgClassType.Value, PgCollectionKey.Value, P
   public getTailConditionFromHeadValue (headValue: PgClassType.Value): Condition {
     return conditionHelpers.and(...this._headFieldNames.map((headFieldName, i) =>
       conditionHelpers.fieldEquals(this._tailFieldNames[i], headValue.get(headFieldName)),
+    ))
+  }
+
+  public getTailConditionFromHeadAlias (aliasIdentifier): Condition {
+    return conditionHelpers.and(...this._headFieldNames.map((headFieldName, i) =>
+      conditionHelpers.fieldEqualsQuery(this._tailFieldNames[i], sql.query`${sql.identifier(aliasIdentifier)}.${sql.identifier(headFieldName)}`),
     ))
   }
 }

--- a/src/postgres/inventory/conditionToSql.ts
+++ b/src/postgres/inventory/conditionToSql.ts
@@ -20,6 +20,8 @@ export default function conditionToSql (condition: Condition, path: Array<string
       return conditionToSql(condition.condition, path.concat([convertRowIdToId && condition.name === 'row_id' ? 'id' : condition.name]), false)
     case 'EQUAL':
       return sql.query`(${sql.identifier(...path)} = ${sql.value(condition.value)})`
+    case 'EQUAL_QUERY':
+      return sql.query`(${sql.identifier(...path)} = ${sql.query`${condition.value}`})`
     case 'LESS_THAN':
       return sql.query`(${sql.identifier(...path)} < ${sql.value(condition.value)})`
     case 'GREATER_THAN':

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
@@ -134,7 +134,7 @@ implements Paginator.Ordering<TInput, PgClassType.Value, AttributesCursor> {
     // hasNextPageSql/hasPreviousPageSql to the query unless they're requested
     const query = sql.query`
       select coalesce(json_agg(${sql.identifier(jsonIdentifier)}), '[]'::json) as "rows",
-      ${totalCountSql} as "totalCount",
+      ${totalCountSql}::integer as "totalCount",
       ${hasNextPageSql} as "hasNextPage",
       ${hasPreviousPageSql} as "hasPreviousPage"
       from (

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
@@ -69,40 +69,52 @@ implements Paginator.Ordering<TInput, PgClassType.Value, AttributesCursor> {
       throw new Error('Before cursor must be a value tuple of the correct length.')
 
     const aliasIdentifier = Symbol()
+    const matchingRowsIdentifier = Symbol()
+    const resultsIdentifier = Symbol()
+    const jsonIdentifier = Symbol()
     const fromSql = this.pgPaginator.getFromEntrySql(input)
     const conditionSql = this.pgPaginator.getConditionSql(input)
 
     const query = sql.compile(sql.query`
-      -- The standard select/from clauses up top.
-      select ${getSelectFragment(resolveInfo, aliasIdentifier, gqlType)} as value
-      from ${fromSql} as ${sql.identifier(aliasIdentifier)}
+      with ${sql.identifier(matchingRowsIdentifier)} as (
+        select *
+        from ${fromSql} as ${sql.identifier(aliasIdentifier)}
 
-      -- Combine our cursors with the condition used for this page to
-      -- implement a where condition which will filter what we want it to.
-      --
-      -- We throw away nulls because there is a lot of wierdness when they
-      -- get included.
-      where
-        ${sql.join(pgAttributes.map(pgAttribute => sql.query`${sql.identifier(pgAttribute.name)} is not null`), ' and ')} and
-        ${beforeCursor ? this._getCursorCondition(pgAttributes, beforeCursor, descending ? '>' : '<') : sql.raw('true')} and
-        ${afterCursor ? this._getCursorCondition(pgAttributes, afterCursor, descending ? '<' : '>') : sql.raw('true')} and
-        ${conditionSql}
+        -- Combine our cursors with the condition used for this page to
+        -- implement a where condition which will filter what we want it to.
+        --
+        -- We throw away nulls because there is a lot of wierdness when they
+        -- get included.
+        where
+          ${sql.join(pgAttributes.map(pgAttribute => sql.query`${sql.identifier(pgAttribute.name)} is not null`), ' and ')} and
+          ${beforeCursor ? this._getCursorCondition(pgAttributes, beforeCursor, descending ? '>' : '<') : sql.raw('true')} and
+          ${afterCursor ? this._getCursorCondition(pgAttributes, afterCursor, descending ? '<' : '>') : sql.raw('true')} and
+          ${conditionSql}
+      ), ${sql.identifier(resultsIdentifier)} as (
+        select json_build_object(
+          'value', ${getSelectFragment(resolveInfo, matchingRowsIdentifier, gqlType)},
+          'cursor', json_build_array(${sql.join(pgAttributes.map(pgAttribute => sql.identifier(pgAttribute.name)), ', ')})
+        ) as ${sql.identifier(jsonIdentifier)}
+        from ${sql.identifier(matchingRowsIdentifier)}
+        -- Order using the same attributes used to construct the cursors. If
+        -- a last property was defined we need to reverse our ordering so the
+        -- limit will work. We will fix the order in JavaScript.
+        order by ${sql.join(pgAttributes.map(pgAttribute =>
+          sql.query`${sql.identifier(pgAttribute.name)} using ${sql.raw((last != null ? !descending : descending) ? '>' : '<')}`,
+        ), ', ')}
 
-      -- Order using the same attributes used to construct the cursors. If
-      -- a last property was defined we need to reverse our ordering so the
-      -- limit will work. We will fix the order in JavaScript.
-      order by ${sql.join(pgAttributes.map(pgAttribute =>
-        sql.query`${sql.identifier(pgAttribute.name)} using ${sql.raw((last != null ? !descending : descending) ? '>' : '<')}`,
-      ), ', ')}
+        -- Finally, apply the appropriate limit.
+        limit ${first != null ? sql.value(first) : last != null ? sql.value(last) : sql.raw('all')}
 
-      -- Finally, apply the appropriate limit.
-      limit ${first != null ? sql.value(first) : last != null ? sql.value(last) : sql.raw('all')}
-
-      -- If we have an offset, add that as well.
-      ${_offset != null ? sql.query`offset ${sql.value(_offset)}` : sql.query``}
+        -- If we have an offset, add that as well.
+        ${_offset != null ? sql.query`offset ${sql.value(_offset)}` : sql.query``}
+      )
+      select coalesce((select json_agg(${sql.identifier(jsonIdentifier)}) from ${sql.identifier(resultsIdentifier)}), '[]'::json) as "rows",
+      false as "hasNextPage",
+      false as "hasPreviousPage"
     `)
 
-    const { rows } = await client.query(query)
+    const { rows: [{rows, hasNextPage, hasPreviousPage}] } = await client.query(query)
 
     // If `last` was defined we reversed the order in Sql so our limit would
     // work. We need to reverse again when we get here.
@@ -111,13 +123,13 @@ implements Paginator.Ordering<TInput, PgClassType.Value, AttributesCursor> {
     // back as an array. We know the final length and we could start
     // returning from the end instead of the beginning.
     if (last != null)
-      rows = rows.reverse()
+      rows.reverse()
 
     // Convert our rows into usable values.
     const values: Array<{ value: PgClassType.Value, cursor: AttributesCursor }> =
-      rows.map(({ value }) => ({
+      rows.map(({ value, cursor }) => ({
         value: this.pgPaginator.itemType.transformPgValueIntoValue(value),
-        cursor: pgAttributes.map(pgAttribute => value[pgAttribute.name]),
+        cursor,
       }))
 
     return {

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts
@@ -152,7 +152,7 @@ implements Paginator.Ordering<TInput, PgClassType.Value, AttributesCursor> {
         -- If we have an offset, add that as well.
         ${_offset != null ? sql.query`offset ${sql.value(_offset)}` : sql.query``}
       ) as ${sql.identifier(resultsIdentifier)}
-    `)
+    `
     return {query, last}
   }
 

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
@@ -149,8 +149,8 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
       )
       select coalesce((select json_agg(${sql.identifier(jsonIdentifier)}) from ${sql.identifier(resultsIdentifier)}), '[]'::json) as "rows",
       (${totalCountSql})::integer as "totalCount",
-      (${hasNextPageSql})::boolean as "hasNextPage",
-      (${offsetSql} > 0) as "hasPreviousPage"
+      (${limit === 0 ? sql.query`false` : hasNextPageSql})::boolean as "hasNextPage",
+      (${limit === 0 ? sql.query`false` : sql.query`${offsetSql} > 0`}) as "hasPreviousPage"
     `
 
     return {query}

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
@@ -65,18 +65,6 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
     if (beforeCursor != null && !Number.isInteger(beforeCursor))
       throw new Error('The before cursor must be an integer.')
 
-    // A private variable where we store the value returned by `getCount`.
-    let _count: number | undefined
-
-    // A local memoized implementation that gets the count of *all* values in
-    // the set we are paginating.
-    const getCount = async () => {
-      if (_count == null)
-        _count = await this.pgPaginator.count(context, input)
-
-      return _count
-    }
-
     let limit: number | null
 
     // If `last` is not defined (which means `first` might be defined), *or*
@@ -193,14 +181,8 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
         cursor,
       }))
 
-    // TODO: We get the count in this function (see `getCount`) to paginate
-    // correctly. We should create an optimization that allows us to share
-    // what the count is instead of calling for the count again.
     return {
       values,
-      // We have super simple implementations for `hasNextPage` and
-      // `hasPreviousPage` thanks to the algebraic nature of ordering by
-      // offset.
       hasNextPage: () => Promise.resolve(hasNextPage),
       hasPreviousPage: () => Promise.resolve(hasPreviousPage),
     }

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
@@ -45,6 +45,7 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
     config: Paginator.PageConfig<AttributesCursor>,
     resolveInfo: mixed,
     gqlType: mixed,
+    subquery?: boolean = true,
   ) {
     const { first, last, beforeCursor, afterCursor, _offset } = config
 
@@ -116,7 +117,7 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
       limit = last
     }
 
-    const fromSql = this.pgPaginator.getFromEntrySql(input)
+    const fromSql = this.pgPaginator.getFromEntrySql(input, subquery)
     const conditionSql = this.pgPaginator.getConditionSql(input)
 
     const hasNextPageSql =
@@ -165,7 +166,7 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
     resolveInfo: mixed,
     gqlType: mixed,
   ): Promise<Paginator.Page<TItemValue, OffsetCursor>> {
-    const details = this.generateQuery(input, config, resolveInfo, gqlType);
+    const details = this.generateQuery(input, config, resolveInfo, gqlType, false);
     const {query} = details
     const compiledQuery = sql.compile(query)
 

--- a/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
+++ b/src/postgres/inventory/paginator/PgPaginatorOrderingOffset.ts
@@ -137,7 +137,7 @@ implements Paginator.Ordering<TInput, TItemValue, OffsetCursor> {
       ), ${sql.identifier(resultsIdentifier)} as (
         select json_build_object(
           'value', ${getSelectFragment(resolveInfo, matchingRowsIdentifier, gqlType)},
-          'cursor', ${offsetSql} + 1 + row_number() over (
+          'cursor', ${offsetSql} + row_number() over (
             ${this.orderBy ? sql.query`order by ${this.orderBy}` : sql.query`order by 0`}
           )
         ) as ${sql.identifier(jsonIdentifier)}

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -71,7 +71,7 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
             queryAST,
           ],
         }
-        fields[sourceName] = field.sqlExpression(aliasIdentifier, fieldName, args, resolveInfo);
+        fields[sourceName] = field.sqlExpression(aliasIdentifier, fieldName, args, resolveInfo)
       }
       return;
     }

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -77,13 +77,11 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
         const sourceName = field.sourceName ? field.sourceName(aliasIdentifier, fieldName, args, alias) : fieldName
         // XXX: is this sufficient?
         const resolveInfo = {
-          parentType: parentGqlType,
+          parentType: fieldGqlType,
           variableValues,
           fragments,
           schema,
-          fieldASTs: [
-            queryAST,
-          ],
+          fieldASTs: queryAST.selectionSet && queryAST.selectionSet.selections.slice(),
         }
         if (fields[sourceName]) {
           const existingEntry = fields[sourceName]

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -113,7 +113,7 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
       return
     }
     // It is related, so continue through it's selection sets
-    queryAST.selectionSet.selections.forEach(
+    queryAST.selectionSet && queryAST.selectionSet.selections.forEach(
       ast => {
         parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, fragments, variableValues, stripNonNullType(stripListType(fieldGqlType)), ast)
       }
@@ -122,7 +122,7 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
     if (queryAST.typeCondition) {
       processFragment(queryAST);
     } else {
-      queryAST.selectionSet.selections.forEach(
+      queryAST.selectionSet && queryAST.selectionSet.selections.forEach(
         selection => parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, fragments, variableValues, parentGqlType, selection)
       );
     }

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -128,17 +128,6 @@ function isRelated(targetGqlType, rawOtherType) {
   )
 }
 
-function getNodeTypeFromRelayType(type, queryASTNode) {
-  const nodeGqlType = stripNonNullType(type._fields.edges.type.ofType._fields.node.type)
-
-  const edges = queryASTNode.selectionSet.selections.find(selection => selection.name.value === 'edges')
-  const nodeQueryAST =
-    edges
-    ? edges.selectionSet.selections.find(selection => selection.name.value === 'node') || {}
-    : {}
-  return { nodeGqlType, nodeQueryAST }
-}
-
 function stripNonNullType(type) {
   return type.constructor.name === 'GraphQLNonNull' ? type.ofType : type
 }

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -56,7 +56,17 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
       const alias = queryAST.alias && queryAST.alias.value
       if (field.sqlExpression) {
         const sqlName = field.sqlName(aliasIdentifier, fieldName, args, alias)
-        fields[sqlName] = field.sqlExpression(aliasIdentifier, fieldName, args);
+        // XXX: is this sufficient?
+        const resolveInfo = {
+          parentType: parentGqlType,
+          variableValues,
+          fragments,
+          schema,
+          fieldASTs: [
+            queryAST,
+          ],
+        }
+        fields[sqlName] = field.sqlExpression(aliasIdentifier, fieldName, args, resolveInfo);
       }
       return;
     }

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -93,7 +93,7 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
           variableValues,
           fragments,
           schema,
-          fieldASTs: queryAST.selectionSet && queryAST.selectionSet.selections.slice(),
+          fieldASTs: queryAST.selectionSet ? queryAST.selectionSet.selections.slice() : [],
         }
         if (fields[sourceName]) {
           const existingEntry = fields[sourceName]

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -2,14 +2,6 @@ import { sql } from '../../utils'
 import { typeFromAST } from 'graphql'
 import { getArgumentValues } from 'graphql/execution/values'
 
-function getFieldFromNode(ast, parentGqlType) {
-  if (ast.kind === 'Field') {
-    const fieldName = ast.name.value
-    return parentGqlType._fields[fieldName]
-  }
-  return
-}
-
 export function getFieldsFromResolveInfo(resolveInfo, aliasIdentifier, rawTargetGqlType) {
   const targetGqlType = stripNonNullType(rawTargetGqlType)
   const {parentType: parentGqlType, variableValues, fragments, schema} = resolveInfo
@@ -56,7 +48,7 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
       // Introspection related
       return;
     }
-    const field = getFieldFromNode(queryAST, parentGqlType)
+    const field = getFieldFromAST(queryAST, parentGqlType)
     const fieldGqlType = stripNonNullType(field.type)
     if (parentGqlType === targetGqlType) { // We're a subfield of the target; HOORAY!
       const args = getArgumentValues(field, queryAST, variableValues)
@@ -112,6 +104,14 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
       }
     }
   }
+}
+
+function getFieldFromAST(ast, parentGqlType) {
+  if (ast.kind === 'Field') {
+    const fieldName = ast.name.value
+    return parentGqlType._fields[fieldName]
+  }
+  return
 }
 
 function isRelated(targetGqlType, rawOtherType) {

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -68,6 +68,7 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
           type: QUERY,
           query: sql.query`${sql.identifier(aliasIdentifier)}.${sql.identifier(field.externalFieldName)}`,
         }
+        return;
       } else if (field.sqlExpression) {
         const sourceName = field.sourceName ? field.sourceName(aliasIdentifier, fieldName, args, alias) : fieldName
         // XXX: is this sufficient?
@@ -103,8 +104,8 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
             resolveInfo,
           };
         }
+        return;
       }
-      return;
     }
     // Not a child of targetGqlType, but maybe we're the type itself; or related to it?
     if (!isRelated(targetGqlType, fieldGqlType)) {

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -18,7 +18,7 @@ export function getFieldsFromResolveInfo(resolveInfo, aliasIdentifier, rawTarget
 export function getSelectFragmentFromFields(fields) {
   const buildArgs = [];
   for (var k in fields) {
-    buildArgs.push(sql.query`${sql.value(k)}::text`, fields[k]);
+    buildArgs.push(sql.literal(k), fields[k]);
   }
   return sql.query`json_build_object(${sql.join(buildArgs, ', ')})`
 }

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -18,7 +18,7 @@ export function getFieldsFromResolveInfo(resolveInfo, aliasIdentifier, rawTarget
       attrName =>  {
         const fld = targetGqlType._fields[attrName]
         if ((attrName === "id" || attrName.endsWith("Id")) && fld.sqlExpression) {
-          fields[fld.sqlName(aliasIdentifier)] = fld.sqlExpression(aliasIdentifier);
+          fields[fld.sqlName(aliasIdentifier, attrName)] = fld.sqlExpression(aliasIdentifier, attrName);
         }
       }
     )
@@ -48,14 +48,15 @@ function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, frag
       // Introspection related
       return;
     }
+    const fieldName = queryAST.name.value
     const field = getFieldFromAST(queryAST, parentGqlType)
     const fieldGqlType = stripNonNullType(field.type)
     if (parentGqlType === targetGqlType) { // We're a subfield of the target; HOORAY!
       const args = getArgumentValues(field, queryAST, variableValues)
       const alias = queryAST.alias && queryAST.alias.value
       if (field.sqlExpression) {
-        const sqlName = field.sqlName(aliasIdentifier, args, alias)
-        fields[sqlName] = field.sqlExpression(aliasIdentifier, args);
+        const sqlName = field.sqlName(aliasIdentifier, fieldName, args, alias)
+        fields[sqlName] = field.sqlExpression(aliasIdentifier, fieldName, args);
       }
       return;
     }

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -18,7 +18,7 @@ export function getFieldsFromResolveInfo(resolveInfo, aliasIdentifier, rawTarget
   return fields;
 }
 
-export function getSelectFragmentFromFields(fields) {
+export function getSelectFragmentFromFields(fields, aliasIdentifier) {
   const buildArgs = [];
   for (var k in fields) {
     const field = fields[k];
@@ -30,14 +30,18 @@ export function getSelectFragmentFromFields(fields) {
     }[field.type](field);
     buildArgs.push(sql.literal(k), arg);
   }
-  return sql.query`json_build_object(${sql.join(buildArgs, ', ')})`
+  if (buildArgs.length === 0) {
+    return sql.query`to_json(${sql.identifier(aliasIdentifier)})`
+  } else {
+    return sql.query`json_build_object(${sql.join(buildArgs, ', ')})`
+  }
 }
 
 export default function getSelectFragment(resolveInfo, aliasIdentifier, targetGqlType) {
   if (!resolveInfo) {
     throw new Error("No resolve info!")
   }
-  return getSelectFragmentFromFields(getFieldsFromResolveInfo(resolveInfo, aliasIdentifier, targetGqlType))
+  return getSelectFragmentFromFields(getFieldsFromResolveInfo(resolveInfo, aliasIdentifier, targetGqlType), aliasIdentifier)
 }
 
 function parseASTIntoFields(fields, aliasIdentifier, schema, targetGqlType, fragments, variableValues, parentGqlType, queryAST) {

--- a/src/postgres/inventory/paginator/getSelectFragment.js
+++ b/src/postgres/inventory/paginator/getSelectFragment.js
@@ -35,8 +35,7 @@ export function getSelectFragmentFromFields(fields) {
 
 export default function getSelectFragment(resolveInfo, aliasIdentifier, targetGqlType) {
   if (!resolveInfo) {
-    if (!process.env.WHATEVER) console.error("This won't work much longer! Just a hack to keep the tests working")
-    return sql.query`to_json(${sql.identifier(aliasIdentifier)})`
+    throw new Error("No resolve info!")
   }
   return getSelectFragmentFromFields(getFieldsFromResolveInfo(resolveInfo, aliasIdentifier, targetGqlType))
 }

--- a/src/postgres/inventory/type/PgClassType.ts
+++ b/src/postgres/inventory/type/PgClassType.ts
@@ -33,6 +33,7 @@ class PgClassType extends PgType<PgRow> implements ObjectType<PgRow> {
         const fieldName = config.renameIdToRowId && pgAttribute.name === 'id' ? 'row_id' : pgAttribute.name
         return [fieldName, {
           description: pgAttribute.description,
+          externalFieldName: pgAttribute.name,
 
           // Make sure that if our attribute specifies that it is non-null,
           // that we remove the types nullable wrapper if it exists.


### PR DESCRIPTION
- [x] calculate hasNextPage/hasPreviousPage in the same query as fetching the data
- [x] remove a source of N+1 queries relating to relations (foo.barsByBazId)

TODO:

- [ ] merge master
- [ ] try and remove additional parameters where possible (requires @calebmer's help)
- [ ] look into using CTEs to bypass performance issues, a la #396 

KNOWN ISSUES:

I've been informed by @cusxio that the following query returns null, but that including the `username` field fixes this - sounds like I need to add `username` to the list of implicit fields on the search endpoints:

```graphql
query {
  userByUsername(username:"cusx") {
    id
  }
}
```

Workaround:

```graphql
query {
  userByUsername(username:"cusx") {
    id
    username
  }
}
```


Fixes #219  
Fixes #265