### PR TITLE
Fix undefined values to be assumed as null values

### DIFF
--- a/src/graphql/schema/type/getGqlInputType.ts
+++ b/src/graphql/schema/type/getGqlInputType.ts
@@ -153,10 +153,17 @@ const createGqlInputType = <TValue>(buildToken: BuildToken, _type: Type<TValue>)
             },
           }))),
         })),
-        fromGqlInput: gqlInput =>
-          gqlInput != null && typeof gqlInput === 'object'
-            ? type.fromFields(new Map(fieldFixtures.map(({ fieldName, key, fromGqlInput }) => [fieldName, fromGqlInput(gqlInput[key])] as [string, mixed])))
-            : (() => { throw new Error(`Input value must be an object, not '${typeof gqlInput}'.`) })(),
+        fromGqlInput: gqlInput => {
+          if (gqlInput === null || typeof gqlInput !== 'object') {
+            throw new Error(`Input value must be an object, not '${typeof gqlInput}'.`)
+          }
+
+          const entries = fieldFixtures
+            .filter(({ key }) => key in gqlInput)
+            .map(({ fieldName, key, fromGqlInput }) => [fieldName, fromGqlInput(gqlInput[key])] as [string, mixed])
+
+          return type.fromFields(new Map(entries))
+        },
       }
     },
 


### PR DESCRIPTION
Problem:
When sending an graphql query that contains the only required values all undefined values in the query get replaced by null in the default sql query mutation builder. This makes the definition of default values when creating a table useless cause the default value is never
applied to the database.

Solution:
This fix makes sure that only defined values in the graphQL mutation get translated to the 
appropriate postgres type and the default pg query builder has a chance to use default instead of null.

The current unit tests do not cover this scenario. I need some generell help how to add such a scenario in postgraphql.

I will also try to improve the query generation in the insertLoader by only including columns defined in the graphql mutation.