### PR TITLE
fix(postgraphql): don't read auth header if auth not enabled

### DIFF
--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -388,7 +388,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
       if (debugGraphql.enabled)
         debugGraphql(printGraphql(queryDocumentAst).replace(/\s+/g, ' ').trim())
 
-      const jwtToken = getJwtToken(req)
+      const jwtToken = options.jwtSecret ? getJwtToken(req) : null
 
       result = await withPostGraphQLContext({
         pgPool,


### PR DESCRIPTION
The documentation says "And if you don’t want authorization, just don’t set the --secret argument and PostGraphQL will ignore all authorization information!"

It turns out postgraphql _does_ read auth information and throws an error if the format is not as expected. This prevents folks from using the Authorization header for non-JWT, like Basic auth.