### PR TITLE
Support mutations that return void

### DIFF
--- a/examples/kitchen-sink/schema.sql
+++ b/examples/kitchen-sink/schema.sql
@@ -164,6 +164,7 @@ create function c.int_set_query(x int, y int, z int) returns setof integer as $$
 create function c.int_set_mutation(x int, y int, z int) returns setof integer as $$ values (1), (2), (3), (4), (x), (y), (z) $$ language sql;
 create function c.no_args_query() returns int as $$ select 2 $$ language sql stable;
 create function c.no_args_mutation() returns int as $$ select 2 $$ language sql;
+create function a.return_void_mutation() returns void as $$ begin return; end; $$ language plpgsql;
 
 create function c.person_first_name(person c.person) returns text as $$ select split_part(person.name, ' ', 1) $$ language sql stable;
 create function c.person_friends(person c.person) returns setof c.person as $$ select friend.* from c.person as friend where friend.id in (person.id + 1, person.id + 2) $$ language sql stable;

--- a/scripts/typecheck
+++ b/scripts/typecheck
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$(npm bin)/tsc --noEmit

--- a/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationMutations-test.js.snap
+++ b/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationMutations-test.js.snap
@@ -675,6 +675,9 @@ Object {
       "clientMutationId": "x",
       "integer": 2,
     },
+    "returnVoidMutation": Object {
+      "__typename": "ReturnVoidMutationPayload",
+    },
     "tableMutation": Object {
       "personByAuthorId": Object {
         "id": 5,

--- a/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationSchema-test.js.snap
+++ b/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationSchema-test.js.snap
@@ -3300,6 +3300,10 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add4MutationInput!
   ): Add4MutationPayload
+  returnVoidMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: ReturnVoidMutationInput!
+  ): ReturnVoidMutationPayload
   authenticate(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateInput!
@@ -4357,6 +4361,23 @@ type Query implements Node {
 
   # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   nodeId: ID!
+}
+
+# All input for the \`returnVoidMutation\` mutation.
+input ReturnVoidMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`returnVoidMutation\` mutation.
+type ReturnVoidMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
 }
 
 type SimilarTable1 implements Node {

--- a/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationSchemaExport-test.js.snap
+++ b/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationSchemaExport-test.js.snap
@@ -1226,6 +1226,10 @@ type Mutation {
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: Add4MutationInput!
   ): Add4MutationPayload
+  returnVoidMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: ReturnVoidMutationInput!
+  ): ReturnVoidMutationPayload
   authenticate(
     # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     input: AuthenticateInput!
@@ -2283,6 +2287,23 @@ type Query implements Node {
 
   # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   nodeId: ID!
+}
+
+# All input for the \`returnVoidMutation\` mutation.
+input ReturnVoidMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`returnVoidMutation\` mutation.
+type ReturnVoidMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
 }
 
 type SimilarTable1 implements Node {
@@ -10964,6 +10985,33 @@ exports[`test exports a schema as JSON 1`] = `
               \"deprecationReason\": null
             },
             {
+              \"name\": \"returnVoidMutation\",
+              \"description\": null,
+              \"args\": [
+                {
+                  \"name\": \"input\",
+                  \"description\": \"The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.\",
+                  \"type\": {
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"INPUT_OBJECT\",
+                      \"name\": \"ReturnVoidMutationInput\",
+                      \"ofType\": null
+                    }
+                  },
+                  \"defaultValue\": null
+                }
+              ],
+              \"type\": {
+                \"kind\": \"OBJECT\",
+                \"name\": \"ReturnVoidMutationPayload\",
+                \"ofType\": null
+              },
+              \"isDeprecated\": false,
+              \"deprecationReason\": null
+            },
+            {
               \"name\": \"authenticate\",
               \"description\": null,
               \"args\": [
@@ -12610,6 +12658,62 @@ exports[`test exports a schema as JSON 1`] = `
               \"type\": {
                 \"kind\": \"SCALAR\",
                 \"name\": \"Int\",
+                \"ofType\": null
+              },
+              \"isDeprecated\": false,
+              \"deprecationReason\": null
+            },
+            {
+              \"name\": \"query\",
+              \"description\": \"Our root query field type. Allows us to run any query from our mutation payload.\",
+              \"args\": [],
+              \"type\": {
+                \"kind\": \"OBJECT\",
+                \"name\": \"Query\",
+                \"ofType\": null
+              },
+              \"isDeprecated\": false,
+              \"deprecationReason\": null
+            }
+          ],
+          \"inputFields\": null,
+          \"interfaces\": [],
+          \"enumValues\": null,
+          \"possibleTypes\": null
+        },
+        {
+          \"kind\": \"INPUT_OBJECT\",
+          \"name\": \"ReturnVoidMutationInput\",
+          \"description\": \"All input for the \`returnVoidMutation\` mutation.\",
+          \"fields\": null,
+          \"inputFields\": [
+            {
+              \"name\": \"clientMutationId\",
+              \"description\": \"An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client.\",
+              \"type\": {
+                \"kind\": \"SCALAR\",
+                \"name\": \"String\",
+                \"ofType\": null
+              },
+              \"defaultValue\": null
+            }
+          ],
+          \"interfaces\": null,
+          \"enumValues\": null,
+          \"possibleTypes\": null
+        },
+        {
+          \"kind\": \"OBJECT\",
+          \"name\": \"ReturnVoidMutationPayload\",
+          \"description\": \"The output of our \`returnVoidMutation\` mutation.\",
+          \"fields\": [
+            {
+              \"name\": \"clientMutationId\",
+              \"description\": \"The exact same \`clientMutationId\` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations.\",
+              \"args\": [],
+              \"type\": {
+                \"kind\": \"SCALAR\",
+                \"name\": \"String\",
                 \"ofType\": null
               },
               \"isDeprecated\": false,

--- a/src/postgraphql/__tests__/fixtures/mutations/procedure-mutation.graphql
+++ b/src/postgraphql/__tests__/fixtures/mutations/procedure-mutation.graphql
@@ -14,4 +14,5 @@ mutation {
   tableSetMutation(input: {}) { people { name } }
   intSetMutation(input: { x: 5, z: 6 }) { integers }
   noArgsMutation(input: { clientMutationId: "x" }) { clientMutationId integer }
+  returnVoidMutation(input: {}) { __typename }
 }

--- a/src/postgraphql/schema/procedures/PgProcedurePaginator.ts
+++ b/src/postgraphql/schema/procedures/PgProcedurePaginator.ts
@@ -26,7 +26,7 @@ class PgProcedurePaginator<TItemValue> extends PgPaginator<ProcedureInput, TItem
   }
 
   public name: string = this._fixtures.pgProcedure.name
-  public itemType: PgType<TItemValue> = this._fixtures.return.type as PgType<TItemValue>
+  public itemType: PgType<TItemValue> = this._fixtures.return!.type as PgType<TItemValue>
 
   /**
    * The different ways we can order our procedure. Of course we can order the

--- a/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureMutationGqlFieldEntry.ts
@@ -36,7 +36,11 @@ export default function createPgProcedureMutationGqlFieldEntry (
   // `PgCollection` which has the same type. If it exists we add some extra
   // stuffs.
   const pgCollection = !pgProcedure.returnsSet
-    ? inventory.getCollections().find(collection => collection instanceof PgCollection && collection.pgClass.typeId === fixtures.return.pgType.id)
+    ? inventory.getCollections().find(collection => (
+      collection instanceof PgCollection &&
+      fixtures.return !== null &&
+      collection.pgClass.typeId === fixtures.return.pgType.id
+    ))
     : null
 
   // Create our GraphQL input fields users will use to input data into our
@@ -56,7 +60,7 @@ export default function createPgProcedureMutationGqlFieldEntry (
     inputFields,
 
     outputFields: [
-      [formatName.field(pgProcedure.returnsSet
+      fixtures.return && [formatName.field(pgProcedure.returnsSet
         // If we are returning a set, we should pluralize the name just in
         // case.
         ? pluralize(getTypeFieldName(fixtures.return.type))
@@ -68,7 +72,7 @@ export default function createPgProcedureMutationGqlFieldEntry (
             ? new GraphQLList(fixtures.return.gqlType)
             : fixtures.return.gqlType,
 
-          resolve: value => fixtures.return.intoGqlOutput(value),
+          resolve: value => fixtures.return!.intoGqlOutput(value),
       }],
 
       // An edge variant of the created value. Because we use cursor
@@ -115,7 +119,7 @@ export default function createPgProcedureMutationGqlFieldEntry (
       )
 
       const { rows } = await client.query(query)
-      const values = rows.map(({ value }) => fixtures.return.type.transformPgValueIntoValue(value))
+      const values = rows.map(({ value }) => fixtures.return !== null ? fixtures.return.type.transformPgValueIntoValue(value) : null)
 
       // If we selected a set of values, return the full set. Otherwise only
       // return the one we queried.

--- a/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
+++ b/src/postgraphql/schema/procedures/createPgProcedureObjectTypeGqlFieldEntry.ts
@@ -39,6 +39,10 @@ function createPgSingleProcedureQueryGqlFieldEntry (
 ): [string, GraphQLFieldConfig<mixed, mixed>] {
   const fixtures = createPgProcedureFixtures(buildToken, pgCatalog, pgProcedure)
 
+  if (fixtures.return === null) {
+    throw new Error('Procedures with a void return type are not allowed in GraphQL queries.')
+  }
+
   // Create our GraphQL input fields users will use to input data into our
   // procedure.
   const argEntries = fixtures.args.slice(1).map<[string, GraphQLArgumentConfig]>(
@@ -59,7 +63,7 @@ function createPgSingleProcedureQueryGqlFieldEntry (
       const input = [source, ...argEntries.map(([argName], i) => fixtures.args[i + 1].fromGqlInput(args[argName]))]
       const query = sql.compile(sql.query`select to_json(${createPgProcedureSqlCall(fixtures, input)}) as value`)
       const { rows: [row] } = await client.query(query)
-      return row ? fixtures.return.intoGqlOutput(fixtures.return.type.transformPgValueIntoValue(row['value'])) : null
+      return row ? fixtures.return!.intoGqlOutput(fixtures.return!.type.transformPgValueIntoValue(row['value'])) : null
     },
   }]
 }

--- a/src/postgres/introspection/__tests__/__snapshots__/introspectDatabase-test.js.snap
+++ b/src/postgres/introspection/__tests__/__snapshots__/introspectDatabase-test.js.snap
@@ -1524,6 +1524,19 @@ Object {
     },
     Object {
       "argDefaultsNum": 0,
+      "argNames": Array [],
+      "argTypeIds": Array [],
+      "description": null,
+      "isStable": false,
+      "isStrict": false,
+      "kind": "procedure",
+      "name": "return_void_mutation",
+      "namespaceId": "a",
+      "returnTypeId": "void",
+      "returnsSet": false,
+    },
+    Object {
+      "argDefaultsNum": 0,
       "argNames": Array [
         "id",
       ],


### PR DESCRIPTION
Fixes https://github.com/postgraphql/postgraphql/issues/429

This PR adds support for procedures that return void as mutations _only_. I don’t see the point in supporting procedures that return void for queries, because if a procedure returns void the likely explanation for doing so is that the procedure is performing some kind of side effect which is not allowed in GraphQL queries. If you can think of a case where return void is good for queries, let us know and we can add support!