### PR TITLE
fix(graphqli): pass along credentials in fetcher

### DIFF
--- a/src/postgraphql/graphiql/src/components/PostGraphiQL.js
+++ b/src/postgraphql/graphiql/src/components/PostGraphiQL.js
@@ -61,6 +61,7 @@ class PostGraphiQL extends React.Component {
       }, jwtToken ? {
         'Authorization': `Bearer ${jwtToken}`,
       } : {}),
+      credentials: 'same-origin',
       body: JSON.stringify(graphQLParams),
     })
 


### PR DESCRIPTION
I'm using basic authentication on my postgraphql endpoint. This configures fetch() to pass along the browser's credentials, which seems to be the norm for other graphiql users like express-graphql:
https://github.com/graphql/express-graphql/blob/master/src/renderGraphiQL.js#L114

Based on my reading of the code, it doesn't appear that `jwtToken` is ever passed in, so I didn't test passing that in. But changing "credentials" to "include" shouldn't result in it being overwritten if it is passed in, according to the fetch spec:
https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
"If httpRequest’s header list contains `Authorization`, then terminate these substeps."