### PR TITLE
Support spaces in folder name

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -10,10 +10,10 @@ rm -rf build
 mkdir build
 
 echo "Compiling with TypeScript"
-$npm_bin/tsc
+"$npm_bin"/tsc
 
 echo "Building GraphiQL"
-(cd src/postgraphql/graphiql && $npm_bin/react-scripts build)
+(cd src/postgraphql/graphiql && "$npm_bin"/react-scripts build)
 
 echo "Moving GraphiQL build output"
 mkdir -p build/postgraphql/graphiql/public


### PR DESCRIPTION
Home directories with spaces in them (forced by companies that don't understand how usernames work) break building the project. Take it or leave it, but this fixes that.