### PR TITLE
Adding schema injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "pg-minify": "^0.4.1",
     "pluralize": "^3.0.0",
     "postgres-interval": "^1.0.2",
+    "require-glob": "^3.2.0",
     "send": "^0.14.1",
     "tslib": "^1.5.0"
   },

--- a/src/graphql/schema/BuildToken.ts
+++ b/src/graphql/schema/BuildToken.ts
@@ -29,6 +29,8 @@ interface BuildToken {
     // If true then the default mutations for tables (e.g. createMyTable) will
     // not be created
     readonly disableDefaultMutations: boolean,
+    // Path to read shcema injections from
+    readonly schemaInjection: string,
   },
   // Hooks for adding custom fields/types into our schema.
   readonly _hooks: _BuildTokenHooks,

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -20,6 +20,8 @@ export type SchemaOptions = {
   // GraphQL types that override the default type generation. Currently this
   // API is private. Use at your own risk.
   _typeOverrides?: _BuildTokenTypeOverrides,
+  // The path to read our injections from
+  schemaInjection?: string,
 }
 
 /**
@@ -36,6 +38,7 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
       nodeIdFieldName: options.nodeIdFieldName || 'nodeId',
       dynamicJson: options.dynamicJson || false,
       disableDefaultMutations: options.disableDefaultMutations || false,
+      schemaInjection: options.schemaInjection || '',
     },
     _hooks: options._hooks || {},
     _typeOverrides: options._typeOverrides || new Map(),

--- a/src/graphql/schema/getMutationGqlType.ts
+++ b/src/graphql/schema/getMutationGqlType.ts
@@ -1,5 +1,5 @@
 import { GraphQLObjectType, GraphQLFieldConfig } from 'graphql'
-import { buildObject, memoize1 } from '../utils'
+import { buildObject, memoize1, loadInjections } from '../utils'
 import BuildToken from './BuildToken'
 import createCollectionMutationFieldEntries from './collection/createCollectionMutationFieldEntries'
 
@@ -37,6 +37,9 @@ function createMutationGqlType (buildToken: BuildToken): GraphQLObjectType | und
             .getCollections()
             .map(collection => createCollectionMutationFieldEntries(buildToken, collection))
             .reduce((a, b) => a.concat(b), [])
+    ),
+    ...(loadInjections(options.schemaInjection, 'mutation')
+
     ),
   ]
 

--- a/src/graphql/schema/getMutationGqlType.ts
+++ b/src/graphql/schema/getMutationGqlType.ts
@@ -38,9 +38,7 @@ function createMutationGqlType (buildToken: BuildToken): GraphQLObjectType | und
             .map(collection => createCollectionMutationFieldEntries(buildToken, collection))
             .reduce((a, b) => a.concat(b), [])
     ),
-    ...(loadInjections(options.schemaInjection, 'mutation')
-
-    ),
+    ...(loadInjections(options.schemaInjection, 'mutation')),
   ]
 
   // If there are no mutation fields, just return to avoid errors.

--- a/src/graphql/schema/getQueryGqlType.ts
+++ b/src/graphql/schema/getQueryGqlType.ts
@@ -36,6 +36,7 @@ function createGqlQueryType (buildToken: BuildToken): GraphQLObjectType {
         .getCollections()
         .map(collection => createCollectionQueryFieldEntries(buildToken, collection))
         .reduce((a, b) => a.concat(b), []),
+      // Load injections
       loadInjections(options.schemaInjection, 'query'),
       [
         // The root query type is useful for Relay 1 as it limits what fields

--- a/src/graphql/schema/getQueryGqlType.ts
+++ b/src/graphql/schema/getQueryGqlType.ts
@@ -1,5 +1,5 @@
 import { GraphQLObjectType, GraphQLFieldConfig, GraphQLNonNull, GraphQLID } from 'graphql'
-import { buildObject, memoize1 } from '../utils'
+import { buildObject, memoize1, loadInjections } from '../utils'
 import createNodeFieldEntry from './node/createNodeFieldEntry'
 import getNodeInterfaceType from './node/getNodeInterfaceType'
 import createCollectionQueryFieldEntries from './collection/createCollectionQueryFieldEntries'
@@ -36,6 +36,7 @@ function createGqlQueryType (buildToken: BuildToken): GraphQLObjectType {
         .getCollections()
         .map(collection => createCollectionQueryFieldEntries(buildToken, collection))
         .reduce((a, b) => a.concat(b), []),
+      loadInjections(options.schemaInjection, 'query'),
       [
         // The root query type is useful for Relay 1 as it limits what fields
         // can be queried at the top level.

--- a/src/graphql/utils/index.ts
+++ b/src/graphql/utils/index.ts
@@ -3,7 +3,8 @@ import formatName from './formatName'
 import idSerde from './idSerde'
 import scrib from './scrib'
 import parseGqlLiteralToValue from './parseGqlLiteralToValue'
+import loadInjections from './loadInjections'
 
-export { buildObject, formatName, idSerde, scrib, parseGqlLiteralToValue }
+export { buildObject, formatName, idSerde, scrib, parseGqlLiteralToValue, loadInjections }
 
 export * from './memoize'

--- a/src/graphql/utils/loadInjections.ts
+++ b/src/graphql/utils/loadInjections.ts
@@ -4,20 +4,51 @@
  */
 
 import {  GraphQLFieldConfig } from 'graphql'
-import * as requireGlob  from 'require-glob'
+import postgraphql from '../../postgraphql/postgraphql'
+const requireGlob = require('require-glob')
+
+let initialized = false
+const queries: Array<[string, GraphQLFieldConfig<never, mixed>]> = []
+const mutations: Array<[string, GraphQLFieldConfig<never, mixed>]> = []
+
+// Sync method to read the injections, populates our injections array
+function initInjections(dirToInject: string): void {
+
+  const files: Array<{ type: string, name: string, schema: (object: {}) => GraphQLFieldConfig<never, mixed> }> = []
+
+  requireGlob.sync(dirToInject, {
+    cwd: process.cwd(),
+    reducer (_options: {}, tree: {} , file: {exports: { type: string, name: string, schema: (object: {}) => GraphQLFieldConfig<never, mixed>}}): {} {
+      files.push({type: file.exports.type, name: file.exports.name, schema: file.exports.schema})
+      return tree
+    },
+  })
+
+  // Resolve each injection to get schema and validate type.
+  files.forEach(file => {
+
+    if (file.type === 'query') {
+      queries.push([file.name, file.schema(postgraphql)])
+    } else if (file.type === 'mutation') {
+      mutations.push([file.name, file.schema(postgraphql)])
+    } else {
+      throw new Error(`Invalid type '${file.type}' in injection named ${file.name}.`)
+    }
+  })
+
+  initialized = true
+}
 
 export default function loadInjections(dirToInject: string, type: string): Array<[string, GraphQLFieldConfig<never, mixed>]> {
 
-  if (dirToInject === '' ) return []
+  if (dirToInject === '' ) {
+    return []
+  }
 
-  const injections = requireGlob.sync(dirToInject, {
-    cwd: process.cwd(),
-		reducer: function (options, tree, file) {
-        if (!Array.isArray(tree)) tree = []
-        if (file.exports.type === type) tree.push([file.exports.name, file.exports.schema])
-        return tree
-      },
-    })
+  if (!initialized) {
+    initInjections(dirToInject)
+  }
 
-  return injections
+  return type === 'query' ? queries : mutations
+
 }

--- a/src/graphql/utils/loadInjections.ts
+++ b/src/graphql/utils/loadInjections.ts
@@ -14,7 +14,7 @@ export default function loadInjections(dirToInject: string, type: string): Array
     cwd: process.cwd(),
 		reducer: function (options, tree, file) {
         if (!Array.isArray(tree)) tree = []
-        if (file.exports.type === type) tree.push([file.exports.name, file.exports.schema)
+        if (file.exports.type === type) tree.push([file.exports.name, file.exports.schema])
         return tree
       },
     })

--- a/src/graphql/utils/loadInjections.ts
+++ b/src/graphql/utils/loadInjections.ts
@@ -1,0 +1,23 @@
+/**
+ * A utility function for requiring all files in a provided directory
+ * Returns an array of double dimensions, as expected by mutationEntries
+ */
+
+import {  GraphQLFieldConfig } from 'graphql'
+import * as requireGlob  from 'require-glob'
+
+export default function loadInjections(dirToInject: string, type: string): Array<[string, GraphQLFieldConfig<never, mixed>]> {
+
+  if (dirToInject === '' ) return []
+
+  const injections = requireGlob.sync(dirToInject, {
+    cwd: process.cwd(),
+		reducer: function (options, tree, file) {
+        if (!Array.isArray(tree)) tree = []
+        if (file.exports.type === type) tree.push([file.exports.name, file.exports.schema)
+        return tree
+      },
+    })
+
+  return injections
+}

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -43,6 +43,7 @@ program
   .option('--export-schema-json [path]', 'enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
   .option('--export-schema-graphql [path]', 'enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
+  .option('--schema-injection [path]', 'requires the files in the specified path and injects them into the GraphQL schema (supports glob\'s)')
 
 program.on('--help', () => console.log(`
   Get Started:
@@ -81,6 +82,7 @@ const {
   exportSchemaGraphql: exportGqlSchemaPath,
   showErrorStack,
   bodySizeLimit,
+  schemaInjection,
 // tslint:disable-next-line no-any
 } = program as any
 
@@ -125,6 +127,7 @@ const server = createServer(postgraphql(pgConfig, schemas, {
   exportJsonSchemaPath,
   exportGqlSchemaPath,
   bodySizeLimit,
+  schemaInjection,
 }))
 
 // Start our server by listening to a specific port and host name. Also log

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -27,6 +27,7 @@ type PostGraphQLOptions = {
   exportGqlSchemaPath?: string,
   bodySizeLimit?: string,
   pgSettings?: { [key: string]: mixed },
+  schemaInjection?: string,
 }
 
 /**

--- a/src/postgraphql/schema/createPostGraphQLSchema.ts
+++ b/src/postgraphql/schema/createPostGraphQLSchema.ts
@@ -26,6 +26,7 @@ export default async function createPostGraphQLSchema (
     jwtSecret?: string,
     jwtPgTypeIdentifier?: string,
     disableDefaultMutations?: boolean,
+    schemaInjection?: string,
   } = {},
 ): Promise<GraphQLSchema> {
   // Create our inventory.
@@ -109,6 +110,7 @@ export default async function createPostGraphQLSchema (
     nodeIdFieldName: options.classicIds ? 'id' : 'nodeId',
     dynamicJson: options.dynamicJson,
     disableDefaultMutations: options.disableDefaultMutations,
+    schemaInjection: options.schemaInjection,
 
     // If we have a JWT Postgres type, let us override the GraphQL output type
     // with our own.

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -70,7 +70,8 @@ export default async function withPostGraphQLContext(
 
     return await callback({
       [$$pgClient]: pgClient,
-      pgRole,
+      pgRole: pgRole.role,
+      jwtClaims: pgRole.jwtClaims,
     })
   }
   // Cleanup our Postgres client by ending the transaction and releasing
@@ -104,7 +105,7 @@ async function setupPgClientTransaction ({
   jwtAudiences?: Array<string>,
   pgDefaultRole?: string,
   pgSettings?: { [key: string]: mixed },
-}): Promise<string | undefined> {
+}): Promise<{role: string | undefined, jwtClaims: {} | undefined}> {
   // Setup our default role. Once we decode our token, the role may change.
   let role = pgDefaultRole
   let jwtClaims: { [claimName: string]: mixed } = {}
@@ -180,7 +181,7 @@ async function setupPgClientTransaction ({
     await pgClient.query(query)
   }
 
-  return role
+  return {role, jwtClaims}
 }
 
 const $$pgClientOrigQuery = Symbol()


### PR DESCRIPTION
Looking for some feedback at this stage on the approach, as a way to solve #300 

Still todo
- Write some tests
- Clean up loadInjections.ts
- Validate the injections to ensure they are the right format (eg contain a schema).

You can load injections using a config param/CLI option that contains the path (supports globs) to your additional schema you want to inject: --schema-injection './injections/**/*.js'

Each file matched is exported to export the following format as an object: 

```javascript
{
    name: "testMutation1",
    type: "mutation",
    schema: {... a valid GraphQL Schema and resolver}
}
```

The type can be either a mutation or a query, and will be injected into the appropriate part of the GraphQL schema.

