### PR TITLE
fix(postgraphql): allow meteor-login-token request header when using enableCors option

### DIFF
--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -515,6 +515,8 @@ function addCORSHeaders (res) {
     // like in a POST request.
     'Content-Type',
     'Content-Length',
+    // Allow meteor-login-token that is sent from the client of a meteor app
+    'meteor-login-token',
   ].join(', '))
 }
 


### PR DESCRIPTION
If you start a PostGraphQL instance using vanilla HTTP within a meteor server the `addCORSHeaders` function needs to allow the `meteor-login-token` request header.  Otherwise the request fails using a GraphQL client (I am using apollo-client).

Here is how I started the instance in Meteor.
```javascript
http.createServer(postgraphql(POSTGRES_CON_STRING, schema, {
  enableCors: true,
  graphiql: Meteor.isDevelopment,
  bodySizeLimit: '20MB'
})).listen(5000);
```

This is what I see when the `meteor-login-token` is now allowed - 

![image](https://cloud.githubusercontent.com/assets/2498502/25501156/4f52d6c6-2b57-11e7-87f9-d689179ccf52.png)

I am considering using PostGraphQL in node.js [as explained here](https://github.com/postgraphql/postgraphql/blob/master/docs/library.md#custom-execution) without going through HTTP but I think there are features that I would lose because I'm using apollo-client.

