### PR TITLE
feature(otherdb): load and dump database introspection result

### DIFF
--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -42,11 +42,13 @@ program
   .option('--export-schema-json [path]', 'enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
   .option('--export-schema-graphql [path]', 'enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
+  .option('--export-introspection-result [path]', 'dump the introspection result')
+  .option('--introspection-result [path]', 'load the introspection result')
 
 program.on('--help', () => console.log(`
   Get Started:
 
-    $ postgraphql --demo
+    $ postgraphql
     $ postgraphql --schema my_schema
 `.slice(1)))
 
@@ -78,6 +80,8 @@ const {
   disableDefaultMutations = false,
   exportSchemaJson: exportJsonSchemaPath,
   exportSchemaGraphql: exportGqlSchemaPath,
+  exportIntrospectionResult: exportIntrospectionResultPath,
+  introspectionResult: introspectionResultPath,
   showErrorStack,
   bodySizeLimit,
 // tslint:disable-next-line no-any
@@ -123,6 +127,8 @@ const server = createServer(postgraphql(pgConfig, schemas, {
   enableCors,
   exportJsonSchemaPath,
   exportGqlSchemaPath,
+  exportIntrospectionResultPath,
+  introspectionResultPath,
   bodySizeLimit,
 }))
 

--- a/src/postgres/introspection/PgCatalog.ts
+++ b/src/postgres/introspection/PgCatalog.ts
@@ -46,6 +46,17 @@ class PgCatalog {
     }
   }
 
+  public toJSON (): string {
+    return JSON.stringify([
+      ...Array.from(this._namespaces.values()),
+      ...Array.from(this._classes.values()),
+      ...Array.from(this._attributes.values()),
+      ...Array.from(this._types.values()),
+      ...Array.from(this._constraints),
+      ...Array.from(this._procedures),
+    ])
+  }
+
   /**
    * Gets all of the namespace objects.
    */


### PR DESCRIPTION
Haven't really tested this yet, just looking to socialize it.

The idea is that many databases implement most postgres features but lack advanced introspection. Also, many developers use migrations to version control their databases across environments. This would make it possible to dump the results of introspection when working with a postgres development database, and load the saved result when pointed at a database that doesn't support the introspection query.

May fix #458