### PR TITLE
feat(postgraphql) Added an option to allow the pgRole to be extracted from anywhere in the JWT

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,7 @@ The usage of the `postgraphql` binary is as follows. To pull up this documentati
     --secret <string>                DEPRECATED: Use jwt-secret instead
     -e, --jwt-secret <string>        the secret to be used when creating and verifying JWTs. if none is provided auth will be disabled
     -A, --jwt-audience <string>      a comma separated list of audiences your jwt token can contain. If no audience is given the audience defaults to `postgraphql`
+    --jwt-role <string>              a comma seperated list of strings that create a path in the jwt from which to extract the postgres role. if none is provided it will use the key `role` on the root of the jwt.
     --export-schema-json [path]      enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.
     --export-schema-graphql [path]   enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.
     --show-error-stack [setting]     show JavaScript error stacks in the GraphQL result errors

--- a/docs/library.md
+++ b/docs/library.md
@@ -59,6 +59,7 @@ Arguments include:
   - `pgDefaultRole`: The default Postgres role to use. If no role was provided in a provided JWT token, this role will be used.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify tokens in the `Authorization` header, and signing JWT tokens you return in procedures.
   - `jwtAudiences`: The audiences to use when verifing the JWT token. If not set the audience will be `['postgraphql']`.
+  - `jwtRole`: a comma seperated list of strings that create a path in the jwt from which to extract the postgres role. if none is provided it will use the key `role` on the root of the jwt.
   - `jwtPgTypeIdentifier`: The Postgres type identifier for the compound type which will be signed as a JWT token if ever found as the return type of a procedure. Can be of the form: `my_schema.my_type`. You may use quotes as needed: `"my-special-schema".my_type`.
   - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does. This feature requires an event trigger to be added to the database by a superuser. When enabled PostGraphQL will try to add this trigger, if you did not connect as a superuser you will get a warning and the trigger won’t be added.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.

--- a/src/postgraphql/__tests__/withPostGraphQLContext-test.js
+++ b/src/postgraphql/__tests__/withPostGraphQLContext-test.js
@@ -239,3 +239,48 @@ test('will set a role provided in the JWT superceding the default role', async (
     ],
   }], ['commit']])
 })
+
+test('will set a role provided in the JWT', async () => {
+  const pgClient = { query: jest.fn(), release: jest.fn() }
+  const pgPool = { connect: jest.fn(() => pgClient) }
+  await withPostGraphQLContext({
+    pgPool,
+    jwtToken: jwt.sign({ aud: 'postgraphql', a: 1, b: 2, c: 3, some: {other: {path: 'test_deep_role' }}}, 'secret', { noTimestamp: true }),
+    jwtSecret: 'secret',
+    jwtRole: ["some", "other", "path"]
+  }, () => {})
+  expect(pgClient.query.mock.calls).toEqual([['begin'], [{
+    text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true), set_config($9, $10, true), set_config($11, $12, true)',
+    values: [
+      'role', 'test_deep_role',
+      'jwt.claims.aud', 'postgraphql',
+      'jwt.claims.a', 1,
+      'jwt.claims.b', 2,
+      'jwt.claims.c', 3,
+      'jwt.claims.some', {"other": {"path": "test_deep_role"}},
+    ],
+  }], ['commit']])
+})
+
+test('will set a role provided in the JWT superceding the default role', async () => {
+  const pgClient = { query: jest.fn(), release: jest.fn() }
+  const pgPool = { connect: jest.fn(() => pgClient) }
+  await withPostGraphQLContext({
+    pgPool,
+    jwtToken: jwt.sign({ aud: 'postgraphql', a: 1, b: 2, c: 3, some: {other: {path: 'test_deep_role' }}}, 'secret', { noTimestamp: true }),
+    jwtSecret: 'secret',
+    jwtRole: ["some", "other", "path"],
+    pgDefaultRole: 'test_default_role',
+  }, () => {})
+  expect(pgClient.query.mock.calls).toEqual([['begin'], [{
+    text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true), set_config($9, $10, true), set_config($11, $12, true)',
+    values: [
+      'role', 'test_deep_role',
+      'jwt.claims.aud', 'postgraphql',
+      'jwt.claims.a', 1,
+      'jwt.claims.b', 2,
+      'jwt.claims.c', 3,
+      'jwt.claims.some', {"other": {"path": "test_deep_role"}},
+    ],
+  }], ['commit']])
+})

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -39,6 +39,7 @@ program
   .option('--secret <string>', 'DEPRECATED: Use jwt-secret instead')
   .option('-e, --jwt-secret <string>', 'the secret to be used when creating and verifying JWTs. if none is provided auth will be disabled')
   .option('-A, --jwt-audiences <string>', 'a comma separated list of audiences your jwt token can contain. If no audience is given the audience defaults to `postgraphql`', (option: string) => option.split(','))
+  .option('--jwt-role <string>', 'a comma seperated list of strings that create a path in the jwt from which to extract the postgres role. if none is provided it will use the key `role` on the root of the jwt.', (option: string) => option.split(','))
   .option('--export-schema-json [path]', 'enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
   .option('--export-schema-graphql [path]', 'enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
@@ -71,6 +72,7 @@ const {
   secret: deprecatedJwtSecret,
   jwtSecret,
   jwtAudiences = ['postgraphql'],
+  jwtRole = ['role'],
   token: jwtPgTypeIdentifier,
   cors: enableCors = false,
   classicIds = false,
@@ -116,6 +118,7 @@ const server = createServer(postgraphql(pgConfig, schemas, {
   jwtPgTypeIdentifier,
   jwtSecret: jwtSecret || deprecatedJwtSecret,
   jwtAudiences,
+  jwtRole,
   pgDefaultRole,
   watchPg,
   showErrorStack,

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -395,6 +395,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
         jwtToken,
         jwtSecret: options.jwtSecret,
         jwtAudiences: options.jwtAudiences,
+        jwtRole: options.jwtRole,
         pgDefaultRole: options.pgDefaultRole,
         pgSettings,
       }, context => {

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -17,6 +17,7 @@ type PostGraphQLOptions = {
   pgDefaultRole?: string,
   jwtSecret?: string,
   jwtAudiences?: Array<string>,
+  jwtRole?: Array<string>,
   jwtPgTypeIdentifier?: string,
   watchPg?: boolean,
   showErrorStack?: boolean,

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -36,6 +36,7 @@ export default async function withPostGraphQLContext(
     jwtToken,
     jwtSecret,
     jwtAudiences = ['postgraphql'],
+    jwtRole = ['role'],
     pgDefaultRole,
     pgSettings,
   }: {
@@ -43,6 +44,7 @@ export default async function withPostGraphQLContext(
     jwtToken?: string,
     jwtSecret?: string,
     jwtAudiences?: Array<string>,
+    jwtRole?: Array<string>,
     pgDefaultRole?: string,
     pgSettings?: { [key: string]: mixed },
   },
@@ -64,6 +66,7 @@ export default async function withPostGraphQLContext(
       jwtToken,
       jwtSecret,
       jwtAudiences,
+      jwtRole,
       pgDefaultRole,
       pgSettings,
     })
@@ -95,6 +98,7 @@ async function setupPgClientTransaction ({
   jwtToken,
   jwtSecret,
   jwtAudiences,
+  jwtRole,
   pgDefaultRole,
   pgSettings,
 }: {
@@ -102,6 +106,7 @@ async function setupPgClientTransaction ({
   jwtToken?: string,
   jwtSecret?: string,
   jwtAudiences?: Array<string>,
+  jwtRole?: Array<string>,
   pgDefaultRole?: string,
   pgSettings?: { [key: string]: mixed },
 }): Promise<string | undefined> {
@@ -124,7 +129,16 @@ async function setupPgClientTransaction ({
         audience: jwtAudiences,
       })
 
-      const roleClaim = jwtClaims['role']
+      let roleClaim = jwtClaims ? jwtClaims : ''
+      const rolePath = jwtRole ? jwtRole : []
+      for (let i = 0; i < rolePath.length; i++) {
+        try {
+          roleClaim = roleClaim[rolePath[i]]
+        } catch (e) {
+          i = rolePath.length
+          roleClaim = ''
+        }
+      }
 
       // If there is a `role` property in the claims, use that instead of our
       // default role.


### PR DESCRIPTION
When working with Auth0 as the source of the JWT it can be difficult to write directly to the root of the jwt (their rules engine allows writing to the jwt but it has to be namespaced with a url-like property name.)

I created this PR that allows you to specify a path in the jwt from which to set the pgRole; if unset it defaults to the current 'role' property on the root of the jwt.

Since this is my first commit I probably missed something, though I did add unit tests where appropriate, updated docs, ran all tests, and tried to follow the commit guidlines.