### PR TITLE
fix(ci) @types/jsonwebtoken >= 7.2.1 requires typescript 2.2 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/debug": "0.0.29",
     "@types/graphql": "^0.8.2",
     "@types/jest": "^16.0.4",
-    "@types/jsonwebtoken": "^7.1.33",
+    "@types/jsonwebtoken": "<7.2.1",
     "@types/node": "^7.0.4",
     "@types/pluralize": "0.0.27",
     "connect": "^3.5.0",


### PR DESCRIPTION
locked version to <7.2.1 until we upgrade rest of code to typescript 2.2

there were some other warnings when I upgraded the typescript dependency to ^2.2.x  and I wasn't quite sure how to fix.  

If you force @types/jsonwebtoken to 7.2.1 you can see the compile error.

Alternative would be to update typescript dependency to 2.2 and fix the three compile warnings.