### PR TITLE
Change jwtPgTypeIdentifier error to warning; fix CI (upgrade GraphiQL/etc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/pluralize": "0.0.27",
     "connect": "^3.5.0",
     "express": "^4.14.0",
-    "graphiql": "0.9.1",
+    "graphiql": "^0.11.2",
     "graphql": "^0.9.3",
     "jest": "^18.1.0",
     "koa": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "nodemon": "^1.11.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-scripts": "0.7.0",
+    "react-scripts": "1.0.10",
     "source-map-support": "^0.4.6",
     "supertest": "^2.0.1",
     "ts-node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "nodemon": "^1.11.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-scripts": "1.0.10",
+    "react-scripts": "0.9.5",
     "source-map-support": "^0.4.6",
     "supertest": "^2.0.1",
     "ts-node": "^2.0.0",

--- a/src/postgraphql/__tests__/postgraphql-test.js
+++ b/src/postgraphql/__tests__/postgraphql-test.js
@@ -139,7 +139,7 @@ test('will create a new PostGraphQL schema on when `watchPgSchemas` emits a chan
   console.log = origLog
 })
 
-test('will error if jwtSecret is provided without jwtPgTypeIdentifier', async () => {
+test('will not error if jwtSecret is provided without jwtPgTypeIdentifier', async () => {
   const pgPool = new Pool()
-  expect(() => postgraphql(pgPool, [], { jwtSecret: 'test' })).toThrow()
+  expect(() => postgraphql(pgPool, [], { jwtSecret: 'test' })).not.toThrow()
 })

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -68,7 +68,8 @@ export default function postgraphql (
   // Check for a jwtSecret without a jwtPgTypeIdentifier
   // a secret without a token identifier prevents JWT creation
   if (options.jwtSecret && !options.jwtPgTypeIdentifier) {
-    throw new Error('jwtSecret provided, however jwtPgTypeIdentifier (token identifier) not provided.')
+    // tslint:disable-next-line no-console
+    console.warn('WARNING: jwtSecret provided, however jwtPgTypeIdentifier (token identifier) not provided.')
   }
 
   // Creates the Postgres schemas array.


### PR DESCRIPTION
Changes the thrown error to simply a console warning.

Regarding #466 

Turns out it's sometimes valid to have jwtSecret but not jwtPgTypeIdentifier.

