### PR TITLE
Introduced pgTransactionSetup option with tests to main postgraphql API

### DIFF
--- a/src/postgraphql/__tests__/withPostGraphQLContext-test.js
+++ b/src/postgraphql/__tests__/withPostGraphQLContext-test.js
@@ -284,3 +284,34 @@ test('will set a role provided in the JWT superceding the default role', async (
     ],
   }], ['commit']])
 })
+
+test('will use provided non-empty transaction setup function', async () => {
+  const testQuery = `select set_config('jwt.claims.aud', 'test_value', true);`;
+  const pgClient = { query: jest.fn(), release: jest.fn() };
+  const pgPool = { connect: jest.fn(() => pgClient) };
+  await withPostGraphQLContext({
+    pgPool,
+    jwtToken: jwt.sign({ aud: 'postgraphql', a: 1, b: 2, c: 3, some: { other: { path: 'test_deep_role' } } }, 'secret', { noTimestamp: true }),
+    jwtSecret: 'secret',
+    jwtRole: ['some', 'other', 'path'],
+    pgDefaultRole: 'test_default_role',
+    pgTransactionSetup: async ({ pgClient }) => {
+      pgClient.query(testQuery);
+    }
+  }, () => { });
+  expect(pgClient.query.mock.calls).toEqual([['begin'], [testQuery], ['commit']]);
+});
+
+test('will use provided empty transaction setup function', async () => {
+  const pgClient = { query: jest.fn(), release: jest.fn() };
+  const pgPool = { connect: jest.fn(() => pgClient) };
+  await withPostGraphQLContext({
+    pgPool,
+    jwtToken: jwt.sign({ aud: 'postgraphql', a: 1, b: 2, c: 3, some: { other: { path: 'test_deep_role' } } }, 'secret', { noTimestamp: true }),
+    jwtSecret: 'secret',
+    jwtRole: ['some', 'other', 'path'],
+    pgDefaultRole: 'test_default_role',
+    pgTransactionSetup: async ({ pgClient }) => { }
+  }, () => { });
+  expect(pgClient.query.mock.calls).toEqual([['begin'], ['commit']]);
+});

--- a/src/postgraphql/__tests__/withPostGraphQLContext-test.js
+++ b/src/postgraphql/__tests__/withPostGraphQLContext-test.js
@@ -286,32 +286,32 @@ test('will set a role provided in the JWT superceding the default role', async (
 })
 
 test('will use provided non-empty transaction setup function', async () => {
-  const testQuery = `select set_config('jwt.claims.aud', 'test_value', true);`;
-  const pgClient = { query: jest.fn(), release: jest.fn() };
-  const pgPool = { connect: jest.fn(() => pgClient) };
+  const testQuery = `select set_config('jwt.claims.aud', 'test_value', true);`
+  const pgClient = { query: jest.fn(), release: jest.fn() }
+  const pgPool = { connect: jest.fn(() => pgClient) }
   await withPostGraphQLContext({
     pgPool,
     jwtToken: jwt.sign({ aud: 'postgraphql', a: 1, b: 2, c: 3, some: { other: { path: 'test_deep_role' } } }, 'secret', { noTimestamp: true }),
     jwtSecret: 'secret',
     jwtRole: ['some', 'other', 'path'],
     pgDefaultRole: 'test_default_role',
-    pgTransactionSetup: async ({ pgClient }) => {
-      pgClient.query(testQuery);
-    }
-  }, () => { });
-  expect(pgClient.query.mock.calls).toEqual([['begin'], [testQuery], ['commit']]);
-});
+    pgTransactionSetup: async (opts) => {
+      opts.pgClient.query(testQuery)
+    },
+  }, () => { })
+  expect(pgClient.query.mock.calls).toEqual([['begin'], [testQuery], ['commit']])
+})
 
 test('will use provided empty transaction setup function', async () => {
-  const pgClient = { query: jest.fn(), release: jest.fn() };
-  const pgPool = { connect: jest.fn(() => pgClient) };
+  const pgClient = { query: jest.fn(), release: jest.fn() }
+  const pgPool = { connect: jest.fn(() => pgClient) }
   await withPostGraphQLContext({
     pgPool,
     jwtToken: jwt.sign({ aud: 'postgraphql', a: 1, b: 2, c: 3, some: { other: { path: 'test_deep_role' } } }, 'secret', { noTimestamp: true }),
     jwtSecret: 'secret',
     jwtRole: ['some', 'other', 'path'],
     pgDefaultRole: 'test_default_role',
-    pgTransactionSetup: async ({ pgClient }) => { }
-  }, () => { });
-  expect(pgClient.query.mock.calls).toEqual([['begin'], ['commit']]);
-});
+    pgTransactionSetup: async () => { },
+  }, () => { })
+  expect(pgClient.query.mock.calls).toEqual([['begin'], ['commit']])
+})

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -401,6 +401,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
         jwtRole: options.jwtRole,
         pgDefaultRole: options.pgDefaultRole,
         pgSettings,
+        pgTransactionSetup: options.pgTransactionSetup,
       }, context => {
         pgRole = context.pgRole
         return executeGraphql(

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'events'
 import { createPostGraphQLSchema, watchPostGraphQLSchema } from 'postgraphile-core'
 import createPostGraphQLHttpRequestHandler, { HttpRequestHandler } from './http/createPostGraphQLHttpRequestHandler'
 import exportPostGraphQLSchema from './schema/exportPostGraphQLSchema'
+import { TransactionSetupOpts } from './withPostGraphQLContext'
 
 type PostGraphQLOptions = {
   classicIds?: boolean,
@@ -26,7 +27,7 @@ type PostGraphQLOptions = {
   exportJsonSchemaPath?: string,
   exportGqlSchemaPath?: string,
   bodySizeLimit?: string,
-  pgTransactionSetup?: (opts: any) => Promise<string | undefined>,
+  pgTransactionSetup?: (opts: TransactionSetupOpts) => Promise<string | undefined>,
   pgSettings?: { [key: string]: mixed },
   appendPlugins?: Array<(builder: mixed) => {}>,
   prependPlugins?: Array<(builder: mixed) => {}>,

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -26,6 +26,7 @@ type PostGraphQLOptions = {
   exportJsonSchemaPath?: string,
   exportGqlSchemaPath?: string,
   bodySizeLimit?: string,
+  pgTransactionSetup?: (opts: any) => Promise<string | undefined>,
   pgSettings?: { [key: string]: mixed },
   appendPlugins?: Array<(builder: mixed) => {}>,
   prependPlugins?: Array<(builder: mixed) => {}>,

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -5,6 +5,16 @@ import { ExecutionResult } from 'graphql'
 import * as sql from 'pg-sql2'
 import { $$pgClient } from '../postgres/inventory/pgClientFromContext'
 
+export interface TransactionSetupOpts {
+  pgClient: Client,
+  jwtToken?: string,
+  jwtSecret?: string,
+  jwtAudiences?: Array<string>,
+  jwtRole: Array<string>,
+  pgDefaultRole?: string,
+  pgSettings?: { [key: string]: mixed },
+}
+
 /**
  * Creates a PostGraphQL context object which should be passed into a GraphQL
  * execution. This function will also connect a client from a Postgres pool and
@@ -48,7 +58,7 @@ export default async function withPostGraphQLContext(
     jwtRole: Array<string>,
     pgDefaultRole?: string,
     pgSettings?: { [key: string]: mixed },
-    pgTransactionSetup?: (opts: any) => Promise<string | undefined>;
+    pgTransactionSetup?: (opts: TransactionSetupOpts) => Promise<string | undefined>;
   },
   callback: (context: mixed) => Promise<ExecutionResult>,
 ): Promise<ExecutionResult> {
@@ -64,7 +74,7 @@ export default async function withPostGraphQLContext(
   // Run the function with a context object that can be passed through
   try {
     if (!pgTransactionSetup) {
-      pgTransactionSetup = setupPgClientTransaction;
+      pgTransactionSetup = setupPgClientTransaction
     }
 
     const pgRole = await pgTransactionSetup({
@@ -107,15 +117,7 @@ async function setupPgClientTransaction ({
   jwtRole,
   pgDefaultRole,
   pgSettings,
-}: {
-  pgClient: Client,
-  jwtToken?: string,
-  jwtSecret?: string,
-  jwtAudiences?: Array<string>,
-  jwtRole: Array<string>,
-  pgDefaultRole?: string,
-  pgSettings?: { [key: string]: mixed },
-}): Promise<string | undefined> {
+}: TransactionSetupOpts): Promise<string | undefined> {
   // Setup our default role. Once we decode our token, the role may change.
   let role = pgDefaultRole
   let jwtClaims: { [claimName: string]: mixed } = {}

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -39,6 +39,7 @@ export default async function withPostGraphQLContext(
     jwtRole = ['role'],
     pgDefaultRole,
     pgSettings,
+    pgTransactionSetup,
   }: {
     pgPool: Pool,
     jwtToken?: string,
@@ -47,6 +48,7 @@ export default async function withPostGraphQLContext(
     jwtRole: Array<string>,
     pgDefaultRole?: string,
     pgSettings?: { [key: string]: mixed },
+    pgTransactionSetup?: (opts: any) => Promise<string | undefined>;
   },
   callback: (context: mixed) => Promise<ExecutionResult>,
 ): Promise<ExecutionResult> {
@@ -61,7 +63,11 @@ export default async function withPostGraphQLContext(
 
   // Run the function with a context object that can be passed through
   try {
-    const pgRole = await setupPgClientTransaction({
+    if (!pgTransactionSetup) {
+      pgTransactionSetup = setupPgClientTransaction;
+    }
+
+    const pgRole = await pgTransactionSetup({
       pgClient,
       jwtToken,
       jwtSecret,


### PR DESCRIPTION
This adds `pgTransactionSetup` option to the top-level middleware API and then propagated up to `withPostGraphQLContext`, which checks if the option is set at all. If not, it's then set to the postgraphql-provided JWT parsing implementation.