### PR TITLE
feat(pgsettings): Only use settings of type string or number

### DIFF
--- a/src/postgraphql/__tests__/withPostGraphQLContext-test.js
+++ b/src/postgraphql/__tests__/withPostGraphQLContext-test.js
@@ -204,8 +204,45 @@ test('extra pgSettings that are objects throw an error', async () => {
   } catch (error) {
     message = error.message
   }
-  expect(message).toBe('Invalid pgSetting: SomeObject is an Object.')
-  expect(pgClient.query).not.toHaveBeenCalled()
+  expect(message).toBe('Error converting pgSetting: object needs to be of type string or number.')
+})
+
+test('extra pgSettings that are symbols throw an error', async () => {
+  const pgClient = { query: jest.fn(), release: jest.fn() }
+  const pgPool = { connect: jest.fn(() => pgClient) }
+  let message
+  try {
+    await withPostGraphQLContext({
+      pgPool,
+      jwtToken: jwt.sign({ aud: 'postgraphql' }, 'secret', { noTimestamp: true }),
+      jwtSecret: 'secret',
+      pgSettings: {
+        'some.symbol': Symbol('some.symbol'),
+      },
+    }, () => {})
+  } catch (error) {
+    message = error.message
+  }
+  expect(message).toBe('Error converting pgSetting: symbol needs to be of type string or number.')
+})
+
+test('extra pgSettings that are booleans throw an error', async () => {
+  const pgClient = { query: jest.fn(), release: jest.fn() }
+  const pgPool = { connect: jest.fn(() => pgClient) }
+  let message
+  try {
+    await withPostGraphQLContext({
+      pgPool,
+      jwtToken: jwt.sign({ aud: 'postgraphql' }, 'secret', { noTimestamp: true }),
+      jwtSecret: 'secret',
+      pgSettings: {
+        'some.boolean': true,
+      },
+    }, () => {})
+  } catch (error) {
+    message = error.message
+  }
+  expect(message).toBe('Error converting pgSetting: boolean needs to be of type string or number.')
 })
 
 test('will set the default role if available', async () => {

--- a/src/postgraphql/__tests__/withPostGraphQLContext-test.js
+++ b/src/postgraphql/__tests__/withPostGraphQLContext-test.js
@@ -178,7 +178,7 @@ test('undefined and null extra settings are ignored while 0 is converted to a st
     },
   }, () => {})
   expect(pgClient.query.mock.calls).toEqual([['begin'], [{
-    text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true)'
+    text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true)',
     values: [
       'foo.bar', 'test1',
       'some.setting.zero', '0',

--- a/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
+++ b/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
@@ -616,7 +616,6 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         pgSettings: {
           'foo.string': 'test1',
           'foo.number': 42,
-          'foo.boolean': true,
         },
       })
       await (
@@ -632,11 +631,10 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         ['begin'],
         [
           {
-            text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true)',
+            text: 'select set_config($1, $2, true), set_config($3, $4, true)',
             values: [
               'foo.string', 'test1',
               'foo.number', '42',
-              'foo.boolean', 'true',
             ],
           },
         ],
@@ -653,7 +651,6 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         pgSettings: (req) => ({
           'foo.string': 'test1',
           'foo.number': 42,
-          'foo.boolean': true,
         }),
       })
       await (
@@ -669,11 +666,10 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         ['begin'],
         [
           {
-            text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true)',
+            text: 'select set_config($1, $2, true), set_config($3, $4, true)',
             values: [
               'foo.string', 'test1',
               'foo.number', '42',
-              'foo.boolean', 'true',
             ],
           },
         ],

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -253,19 +253,20 @@ function getPath(inObject: mixed, path: Array<string>): any {
 }
 
 /**
- * Check if a pgSetting is valid.
- * Null and Undefined settings are not valid.
- * pgSettings objects throw an error.
+ * Check if a pgSetting is a string or a number.
+ * Null and Undefined settings are not valid and will be ignored.
+ * pgSettings of other types throw an error.
  *
  * @private
  */
 function isPgSettingValid(pgSetting: mixed): boolean {
+  const supportedSettingTypes = ['string', 'number']
+  if (supportedSettingTypes.indexOf(typeof pgSetting) >= 0) {
+    return true
+  }
   if (pgSetting === undefined || pgSetting === null) {
     return false
   }
-  if (typeof pgSetting === 'object') {
-    throw new Error(`Invalid pgSetting: ${pgSetting} is an Object.`)
-  }
-  return true
+  throw new Error(`Error converting pgSetting: ${typeof pgSetting} needs to be of type ${supportedSettingTypes.join(' or ')}.`)
 }
 // tslint:enable no-any

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -163,7 +163,9 @@ async function setupPgClientTransaction ({
   // this prevents an accidentional overwriting
   if (typeof pgSettings === 'object') {
     for (const key of Object.keys(pgSettings)) {
-      localSettings.set(key, !!pgSettings[key] ? String(pgSettings[key]) : null)
+      if (isPgSettingValid(pgSettings[key])) {
+        localSettings.set(key, String(pgSettings[key]))
+      }
     }
   }
 
@@ -248,5 +250,22 @@ function getPath(inObject: mixed, path: Array<string>): any {
     object = object[path[index++]]
   }
   return (index && index === length) ? object : undefined
+}
+
+/**
+ * Check if a pgSetting is valid.
+ * Null and Undefined settings are not valid.
+ * pgSettings objects throw an error.
+ *
+ * @private
+ */
+function isPgSettingValid(pgSetting: mixed): boolean {
+  if (pgSetting === undefined || pgSetting === null) {
+    return false
+  }
+  if (typeof pgSetting === 'object') {
+    throw new Error(`Invalid pgSetting: ${pgSetting} is an Object.`)
+  }
+  return true
 }
 // tslint:enable no-any

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -163,7 +163,7 @@ async function setupPgClientTransaction ({
   // this prevents an accidentional overwriting
   if (typeof pgSettings === 'object') {
     for (const key of Object.keys(pgSettings)) {
-      localSettings.set(key, String(pgSettings[key]))
+      localSettings.set(key, !!pgSettings[key] ? String(pgSettings[key]) : null)
     }
   }
 


### PR DESCRIPTION
~~For example, instead of an `undefined` pgSetting becoming `"undefined"` turn it into `null` so `set_config` can still accept it~~

Fixes: #566 