### PR TITLE
feat(postgraphql): Provide mechanism to add data to resolver context

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -69,7 +69,7 @@ Arguments include:
   - `exportJsonSchemaPath`: Enables saving the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.
   - `exportGqlSchemaPath`: Enables saving the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.
   - `bodySizeLimit`: Set the maximum size of JSON bodies that can be parsed (default 100kB). The size can be given as a human-readable string, such as '200kB' or '5MB' (case insensitive).
-  - `additionalGraphqlContextFromRequest`: Providing a function to this and it will be called for each request and the result added to the context passed in to each resolver. This can be used in conjunction with plugins to adapt resolver behaviour based on custom information in the request object.
+  - `additionalGraphQLContextFromRequest`: Provide an async function to this to add custom items to the context being provided to each graphQL resolver. The input is the incoming request object, allowing you to write plugins which adapt behaviour based on the request.
 
 [connect]: https://www.npmjs.com/connect
 [express]: https://www.npmjs.com/express

--- a/docs/library.md
+++ b/docs/library.md
@@ -69,6 +69,7 @@ Arguments include:
   - `exportJsonSchemaPath`: Enables saving the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.
   - `exportGqlSchemaPath`: Enables saving the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.
   - `bodySizeLimit`: Set the maximum size of JSON bodies that can be parsed (default 100kB). The size can be given as a human-readable string, such as '200kB' or '5MB' (case insensitive).
+  - `additionalGraphqlContextFromRequest`: Providing a function to this and it will be called for each request and the result added to the context passed in to each resolver. This can be used in conjunction with plugins to adapt resolver behaviour based on custom information in the request object.
 
 [connect]: https://www.npmjs.com/connect
 [express]: https://www.npmjs.com/express

--- a/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
+++ b/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
@@ -682,7 +682,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       expect(pgClient.release.mock.calls).toEqual([[]])
     })
 
-    test('will call additionalGraphqlContextFromRequest if provided and add the response to the context', async () => {
+    test('will call additionalGraphQLContextFromRequest if provided and add the response to the context', async () => {
       const helloResolver = jest.fn((source, args, context) => context.additional)
       const contextCheckGqlSchema = new GraphQLSchema({
         query: new GraphQLObjectType({
@@ -695,10 +695,10 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
           },
         }),
       })
-      const additionalGraphqlContextFromRequest = jest.fn(() => ({ additional: 'foo' }))
+      const additionalGraphQLContextFromRequest = jest.fn(() => ({ additional: 'foo' }))
       const server = createServer({
-        additionalGraphqlContextFromRequest,
-        getGqlSchema: () => contextCheckGqlSchema,
+        additionalGraphQLContextFromRequest,
+        getGqlSchema: () => Promise.resolve(contextCheckGqlSchema),
       })
 
       await (
@@ -709,8 +709,8 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         .expect('Content-Type', /json/)
         .expect({ data: { hello: 'foo' } })
       )
-      expect(additionalGraphqlContextFromRequest).toHaveBeenCalledTimes(1)
-      expect(additionalGraphqlContextFromRequest.mock.calls[0][0]).toBeInstanceOf(http.IncomingMessage)
+      expect(additionalGraphQLContextFromRequest).toHaveBeenCalledTimes(1)
+      expect(additionalGraphQLContextFromRequest.mock.calls[0][0]).toBeInstanceOf(http.IncomingMessage)
     })
   })
 }

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
@@ -87,7 +87,7 @@ export default function createPostGraphQLHttpRequestHandler (config: {
   // in postgres functions.
   pgSettings?: { [key: string]: mixed },
 
-  // Providing a function to this and it will be called for each request and the
-  // result added to the context passed in to each resolver.
-  additionalGraphqlContextFromRequest?: (req: IncomingMessage) => {},
+  // Provide an async function to this to add custom properties to the context
+  // object being provided to each graphQL resolver.
+  additionalGraphQLContextFromRequest?: (req: IncomingMessage) => Promise<{}>,
 }): HttpRequestHandler

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
@@ -86,4 +86,8 @@ export default function createPostGraphQLHttpRequestHandler (config: {
   // each transaction via set_config. They can then be used via current_setting
   // in postgres functions.
   pgSettings?: { [key: string]: mixed },
+
+  // Providing a function to this and it will be called for each request and the
+  // result added to the context passed in to each resolver.
+  additionalGraphqlContextFromRequest?: (req: IncomingMessage) => {},
 }): HttpRequestHandler

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -401,6 +401,9 @@ export default function createPostGraphQLHttpRequestHandler (options) {
       const jwtToken = options.jwtSecret ? getJwtToken(req) : null
       const { jwtSecret, jwtAudiences, jwtRole, pgDefaultRole, additionalGraphqlContextFromRequest } = options
 
+      const additionalContext = typeof additionalGraphQLContextFromRequest === 'function'
+        ? await additionalGraphQLContextFromRequest(req)
+        : {}
       result = await withPostGraphQLContext({
         pgPool,
         jwtToken,
@@ -412,9 +415,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
           typeof pgSettings === 'function' ? await pgSettings(req) : pgSettings,
       }, context => {
         pgRole = context.pgRole
-        const graphqlContext = typeof additionalGraphqlContextFromRequest === 'function'
-          ? Object.assign({}, additionalGraphqlContextFromRequest(req), context)
-          : context
+        const graphqlContext = Object.assign({}, additionalContext, context)
         return executeGraphql(
           gqlSchema,
           queryDocumentAst,

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -66,7 +66,7 @@ const origGraphiqlHtml = new Promise((resolve, reject) => {
  * @param {GraphQLSchema} graphqlSchema
  */
 export default function createPostGraphQLHttpRequestHandler (options) {
-  const { getGqlSchema, pgPool, pgSettings, pgDefaultRole } = options
+  const { getGqlSchema, pgPool, pgSettings, pgDefaultRole, jwtSecret, jwtAudiences, jwtRole, additionalGraphQLContextFromRequest } = options
 
   if (pgDefaultRole && typeof pgSettings === 'function') {
     throw new Error('pgDefaultRole cannot be combined with pgSettings(req) - please remove pgDefaultRole and instead always return a `role` key from pgSettings(req).')
@@ -399,7 +399,6 @@ export default function createPostGraphQLHttpRequestHandler (options) {
         debugGraphql(printGraphql(queryDocumentAst).replace(/\s+/g, ' ').trim())
 
       const jwtToken = options.jwtSecret ? getJwtToken(req) : null
-      const { jwtSecret, jwtAudiences, jwtRole, pgDefaultRole, additionalGraphqlContextFromRequest } = options
 
       const additionalContext = typeof additionalGraphQLContextFromRequest === 'function'
         ? await additionalGraphQLContextFromRequest(req)

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -31,6 +31,7 @@ type PostGraphQLOptions = {
   appendPlugins?: Array<(builder: mixed) => {}>,
   prependPlugins?: Array<(builder: mixed) => {}>,
   replaceAllPlugins?: Array<(builder: mixed) => {}>,
+  additionalGraphqlContextFromRequest?: (req: IncomingMessage) => {},
 }
 
 /**

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -31,7 +31,7 @@ type PostGraphQLOptions = {
   appendPlugins?: Array<(builder: mixed) => {}>,
   prependPlugins?: Array<(builder: mixed) => {}>,
   replaceAllPlugins?: Array<(builder: mixed) => {}>,
-  additionalGraphqlContextFromRequest?: (req: IncomingMessage) => {},
+  additionalGraphQLContextFromRequest?: (req: IncomingMessage) => Promise<{}>,
 }
 
 /**


### PR DESCRIPTION
Add an optional parameter called `additionalGraphqlContextFromRequest` to the options object supplied to the postgraphile middleware [here](https://www.graphile.org/postgraphile/usage-library/#api-postgraphilepgconfig-schemaname-options)

This should be provided an async function which resolves to an object. It will be called upon graphql requests, and provided the incoming request object. The resultant object is then applied to the context passed to all graphql resolvers.

This will allow us to add extra information from the request into the graphql resolver context, which when writing custom plugins will be useful for instances such as personalisation or auth flows outside of postgres.

Cheers for the library, think it's awesome. 
