### PR TITLE
Avoid pgDefaultRole/pgSettings() clashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphql",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘",
   "author": "Caleb Meredith <calebmeredith8@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
`pgDefaultRole`, if set, overrides the `role` returned by `pgSettings`. We could fix this, but since this behaviour already existed it would be a breaking change (and have security implications besides!) so instead this version will throw if this invalid behaviour might take place.

In a later release we might let these options co-exist again (but the right way around!)