### PR TITLE
Remove middle layers from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /postgraphql
 RUN sed -i 's/\"graphql\": \">=0.6 <0.13\"/\"graphql\": \">=0.6 <0.12\"/g' package.json
 
 RUN apk add --update bash && rm -rf /var/cache/apk/* && \
-    mkdir -p /postgraphql && \
     npm install && \
     scripts/build && \
     npm pack && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,20 @@ FROM node:alpine
 LABEL description="A GraphQL API created by reflection over a PostgreSQL schmea https://github.com/postgraphql/postgraphql"
 
 # alpine linux standard doesn't include bash, and postgraphql scripts have #! bash
-RUN apk add --update bash && rm -rf /var/cache/apk/*
-
-RUN mkdir -p /postgraphql
+COPY . /postgraphql
 WORKDIR /postgraphql
 
-COPY . /postgraphql
 
 # Temporary pin of graphql to less than 0.12 in package.json
 RUN sed -i 's/\"graphql\": \">=0.6 <0.13\"/\"graphql\": \">=0.6 <0.12\"/g' package.json
 
-RUN npm install
-RUN scripts/build
-RUN npm pack
-RUN npm install -g postgraphql-*.tgz
+RUN apk add --update bash && rm -rf /var/cache/apk/* && \
+    mkdir -p /postgraphql && \
+    npm install && \
+    scripts/build && \
+    npm pack && \
+    npm install -g postgraphql-*.tgz && \
+    rm -rf /postgraphql
 
-RUN rm -rf /postgraphql
 EXPOSE 5000
 ENTRYPOINT ["postgraphql", "-n", "0.0.0.0"]


### PR DESCRIPTION
This should decrease the docker image, because each RUN command creates new layer in docker image.
Image size reduction 278MB -> 142MB.