### PR TITLE
fix(docs): Fix pg-pool import in library.md

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -92,12 +92,12 @@ createPostGraphQLSchema('postgres://localhost:5432')
 
 Now that you have your schema, in order to execute a GraphQL query you will need to get a PostGraphQL context object with `withPostGraphQLContext`. The context object will contain a Postgres client which has its own transaction with the correct permission levels for the associated user.
 
-You will also need a Postgres pool from the [`pg-pool`][] module.
+You will also need a Postgres pool from the [`pg`][] module.
 
 `withPostGraphQLContext`, like `createPostGraphQLSchema`, will also return a promise.
 
 ```js
-import Pool from 'pg-pool'
+import { Pool } from 'pg'
 import { graphql } from 'graphql'
 import { withPostGraphQLContext } from 'postgraphql'
 
@@ -145,7 +145,7 @@ Arguments include:
 This function sets up a PostGraphQL context, calls (and resolves) the callback function within this context, and then tears the context back down again finally resolving to the result of your function. The callback is expected to return a promise which resolves to a GraphQL execution result. The context you get as an argument to `callback` will be invalid anywhere outside of the `callback` function.
 
 - **`options`**: An object of options that are used to create the context object that gets passed into `callback`.
-  - `pgPool`: A required instance of a Postgres pool from [`pg-pool`][]. A Postgres client will be connected from this pool.
+  - `pgPool`: A required instance of a Postgres pool from [`https://www.npmjs.com/package/pg`][]. A Postgres client will be connected from this pool.
   - `jwtToken`: An optional JWT token string. This JWT token represents the viewer of your PostGraphQL schema.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify the `jwtToken`.
   - `jwtAudiences`: The audiences to use when verifying the JWT token. If not set the audience will be `['postgraphql']`.
@@ -155,4 +155,4 @@ This function sets up a PostGraphQL context, calls (and resolves) the callback f
 - **`callback`**: The function which is called with the `context` object which was created. Whatever the return value of this function is will be the return value of `withPostGraphQLContext`.
 
 [GraphQL-js]: https://www.npmjs.com/package/graphql
-[`pg-pool`]: https://www.npmjs.com/package/pg-pool
+[`pg`]: https://www.npmjs.com/package/pg

--- a/docs/library.md
+++ b/docs/library.md
@@ -145,7 +145,7 @@ Arguments include:
 This function sets up a PostGraphQL context, calls (and resolves) the callback function within this context, and then tears the context back down again finally resolving to the result of your function. The callback is expected to return a promise which resolves to a GraphQL execution result. The context you get as an argument to `callback` will be invalid anywhere outside of the `callback` function.
 
 - **`options`**: An object of options that are used to create the context object that gets passed into `callback`.
-  - `pgPool`: A required instance of a Postgres pool from [`https://www.npmjs.com/package/pg`][]. A Postgres client will be connected from this pool.
+  - `pgPool`: A required instance of a Postgres pool from [`pg`][]. A Postgres client will be connected from this pool.
   - `jwtToken`: An optional JWT token string. This JWT token represents the viewer of your PostGraphQL schema.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify the `jwtToken`.
   - `jwtAudiences`: The audiences to use when verifying the JWT token. If not set the audience will be `['postgraphql']`.

--- a/docs/library.md
+++ b/docs/library.md
@@ -97,7 +97,7 @@ You will also need a Postgres pool from the [`pg-pool`][] module.
 `withPostGraphQLContext`, like `createPostGraphQLSchema`, will also return a promise.
 
 ```js
-import { Pool } from 'pg-pool'
+import Pool from 'pg-pool'
 import { graphql } from 'graphql'
 import { withPostGraphQLContext } from 'postgraphql'
 


### PR DESCRIPTION
Another tiny documentation fix: The `Pool` import is the default/unnamed export of the standalone `pg-pool` module as seen in the [docs](https://github.com/brianc/node-pg-pool/blob/master/README.md).

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>